### PR TITLE
Fixed erroneous encoding declarations

### DIFF
--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 """
 
  This file is part of OpenModelica.

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 """
 OMPython is a Python interface to OpenModelica.
 To get started, create an OMCSession object:


### PR DESCRIPTION
The 2 `__init__.py` files both claimed to be `cp1252` encoding. In fact, they are utf-8 encoded. This was easily visible due to the ö in Linköpings.