### PR TITLE
Streamline typeCheck and add initial test suite

### DIFF
--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -41,36 +41,28 @@ next_set_list = []
 next_set = []
 next_set.append('')
 
+def bool_from_string(string):
+    if string in {'true', 'True', 'TRUE'}:
+        return True
+    elif string in {'false', 'False', 'FALSE'}:
+        return False
+    else:
+        raise ValueError
+
 def typeCheck(string):
-    if "\n" in string:
-        new_line_char = string[-1]
-        if new_line_char == "\n":
-            string = string.replace(string[-1],'').strip()
+    """Attempt conversion of string to a usable value"""
+    types = [bool_from_string, int, float, long, dict, str]
 
-    if string == "true" or string == "True" or string == "TRUE":
-        string = True
-        return string
-    elif string == "false" or string == "False" or string == "FALSE":
-        string = False
-        return string
+    string = string.strip()
 
-    try:
-        string = int(string)
-    except ValueError:
+    for t in types:
         try:
-            string = float(string)
+            return t(string)
         except ValueError:
-            try:
-                string = long(string)
-            except ValueError:
-                try:
-                    string = dict(string)
-                except ValueError:
-                    try:
-                        string = str(string)
-                    except ValueError:
-                        print ("String contains Un-handled datatype")
-    return string
+            continue
+    else:
+        print("String contains un-handled datatype")
+        return string
 
 def make_values(strings, name):
     if strings[0] == "(" and strings[-1]==")":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-from OMPython import OMParser
-
 __all__ = ['tests.test_OMParser']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from OMPython import OMParser
+
+__all__ = ['tests.test_OMParser']

--- a/tests/test_OMParser.py
+++ b/tests/test_OMParser.py
@@ -1,0 +1,39 @@
+import unittest
+
+from OMPython import OMParser
+
+typeCheck = OMParser.typeCheck
+
+class TypeCheckTester(unittest.TestCase):
+    def testNewlineBehaviour(self):
+        pass
+
+    def testBoolean(self):
+        self.assertEqual(typeCheck('TRUE'), True)
+        self.assertEqual(typeCheck('True'), True)
+        self.assertEqual(typeCheck('true'), True)
+        self.assertEqual(typeCheck('FALSE'), False)
+        self.assertEqual(typeCheck('False'), False)
+        self.assertEqual(typeCheck('false'), False)
+
+    def testInt(self):
+        self.assertEqual(typeCheck('2'), 2)
+        self.assertEqual(type(typeCheck('1')), int)
+
+    def testFloat(self):
+        self.assertEqual(type(typeCheck('1.2e3')), float)
+
+    def testLong(self):
+        self.assertEqual(type(typeCheck('123123123123123123232323')), long)
+
+    # def testDict(self):
+    #     self.assertEqual(type(typeCheck('{"a": "b"}')), dict)
+
+    def testStr(self):
+        pass
+
+    def testUnStringable(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've started by making typeCheck easier to change by changing the order and contents of the types variable rather than redoing logic. In the process I've also started a small test suite to make sure I don't mess anything up with the edits.

I am a bit puzzled by what kind of thing will raise ValueError when passed to `str` in Python, so the final tests are empty right now.
