### PR TITLE
Improvements to behaviour of ModelicaSystem class

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1166,8 +1166,7 @@ class ModelicaSystem(object):
         res_mat = '_res.mat'
         resFile = "".join([self.modelName, res_mat])
         if (not os.path.exists(resFile)):
-            print ("Error: Result file does not exist")
-            sys.exit()
+            raise IOError("Result file does not exist")
         else:
             if len(varList) == 0:
                 #validSolution = ['time'] + self.__getInputNames() + self.__getContinuousNames() + self.__getParameterNames()

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1167,7 +1167,7 @@ class ModelicaSystem(object):
         resFile = "".join([self.modelName, res_mat])
         if (not os.path.exists(resFile)):
             print ("Error: Result file does not exist")
-            exit()
+            sys.exit()
         else:
             if len(varList) == 0:
                 #validSolution = ['time'] + self.__getInputNames() + self.__getContinuousNames() + self.__getParameterNames()

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1396,7 +1396,8 @@ class ModelicaSystem(object):
                             if l.changable == 'false':
                                 print ("!!! value cannot be set for " + n)
                             else:
-                                l.start = float(nameVal.get(n))
+                                # l.start = float(nameVal.get(n))
+                                l.start = nameVal.get(n)
                                 index_ = namesList.index(n)
                                 valuesList[index_] = l.start
                                 
@@ -1405,7 +1406,8 @@ class ModelicaSystem(object):
                                     if paramVar.get('name') == str(n):
                                         c=paramVar.getchildren()
                                         for attr in c:
-                                            val = float(nameVal.get(n))
+                                            # val = float(nameVal.get(n))
+                                            val = nameVal.get(n)
                                             attr.set('start', str(val))
                                             self.tree.write(self.xmlFile,  encoding='UTF-8', xml_declaration=True)
                                 index = index + 1

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -944,7 +944,10 @@ class ModelicaSystem(object):
                                 str_ = False
                             self.pValuesList.append(str_)
                         else:
-                            self.pValuesList.append(float(str_))
+                            try:
+                                self.pValuesList.append(float(str_))
+                            except ValueError:
+                                self.pValuesList.append(str_)
             return self.pValuesList
         else:
             try:


### PR DESCRIPTION
I think it would be useful to add these changes to OMPython:

1.) When calling getParameters() and if a parameter is a string that is not true or false and cannot be converted to a float, return the string value instead of throwing an error, since the parameter then probably is a string (e. g. a file path)

2.) When calling getSolutions() and no solution is present yet, the undefined function exit() is called, while I think sys.exit() should be called

