### PR TITLE
autopep8 --max-line-length=999

### DIFF
--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -41,6 +41,7 @@ next_set_list = []
 next_set = []
 next_set.append('')
 
+
 def bool_from_string(string):
     if string in {'true', 'True', 'TRUE'}:
         return True
@@ -48,6 +49,7 @@ def bool_from_string(string):
         return False
     else:
         raise ValueError
+
 
 def typeCheck(string):
     """Attempt conversion of string to a usable value"""
@@ -64,10 +66,11 @@ def typeCheck(string):
         print("String contains un-handled datatype")
         return string
 
+
 def make_values(strings, name):
-    if strings[0] == "(" and strings[-1]==")":
+    if strings[0] == "(" and strings[-1] == ")":
         strings = strings[1:-1]
-    if strings[0] == "{" and strings[-1]=="}":
+    if strings[0] == "{" and strings[-1] == "}":
         strings = strings[1:-1]
 
     """ find the highest Set number of SET """
@@ -75,9 +78,9 @@ def make_values(strings, name):
         if each_name.find("SET") != -1:
             main_set_name = each_name
 
-    if strings[0] == "\"" and strings[-1]=="\"":
-        strings = strings.replace("\\\"","\"")
-        result[main_set_name]['Values']=[]
+    if strings[0] == "\"" and strings[-1] == "\"":
+        strings = strings.replace("\\\"", "\"")
+        result[main_set_name]['Values'] = []
         result[main_set_name]['Values'].append(strings)
     else:
         anchor = 0
@@ -87,52 +90,52 @@ def make_values(strings, name):
         main_set_name = "SET1"
 
         """ remove braces & keep only the SET's values. """
-        while position <len(prop_str):
-                check = prop_str[position]
-                if check == "{":
-                        anchor = position
-                elif check == "}":
-                        stop = position
-                        delStr = prop_str[anchor:stop+1]
+        while position < len(prop_str):
+            check = prop_str[position]
+            if check == "{":
+                anchor = position
+            elif check == "}":
+                stop = position
+                delStr = prop_str[anchor:stop + 1]
 
-                        i = anchor
-                        while i > 0:
-                            text = prop_str[i]
-                            if text == ",":
-                                name_start = i+1
-                                break
-                            i -=1
-                        name_of_set = prop_str[name_start:anchor]
-                        if name_of_set.find("=") ==-1:
-                            prop_str = prop_str.replace(delStr,'').strip()
-                            position = 0
+                i = anchor
+                while i > 0:
+                    text = prop_str[i]
+                    if text == ",":
+                        name_start = i + 1
+                        break
+                    i -= 1
+                name_of_set = prop_str[name_start:anchor]
+                if name_of_set.find("=") == -1:
+                    prop_str = prop_str.replace(delStr, '').strip()
+                    position = 0
 
-                position +=1
+            position += 1
 
         for each_name in result:
             if each_name.find("SET") != -1:
                 main_set_name = each_name
 
-        values=[]
+        values = []
         anchor = 0
         brace_count = 0
-        for i,c in enumerate(prop_str):
-            if c == "," and brace_count==0:
+        for i, c in enumerate(prop_str):
+            if c == "," and brace_count == 0:
                 value = prop_str[anchor:i]
                 value = (value.lstrip()).rstrip()
                 if "=" in value:
-                    result[main_set_name]['Elements'][name]['Properties']['Results']={}
+                    result[main_set_name]['Elements'][name]['Properties']['Results'] = {}
                 else:
-                    result[main_set_name]['Elements'][name]['Properties']['Values']=[]
+                    result[main_set_name]['Elements'][name]['Properties']['Values'] = []
                 values.append(value)
-                anchor = i+1
+                anchor = i + 1
             elif c == "{":
-                brace_count +=1
+                brace_count += 1
             elif c == "}":
-                brace_count -=1
+                brace_count -= 1
 
-            if i == len(prop_str)-1:
-                values.append(((prop_str[anchor:i+1]).lstrip()).rstrip())
+            if i == len(prop_str) - 1:
+                values.append(((prop_str[anchor:i + 1]).lstrip()).rstrip())
 
         for each_val in values:
             multiple_values = []
@@ -140,17 +143,17 @@ def make_values(strings, name):
                 pos = each_val.find("=")
                 varName = each_val[0:pos]
                 varName = typeCheck(varName)
-                varValue = each_val[pos+1:len(each_val)]
-                if varValue !="":
+                varValue = each_val[pos + 1:len(each_val)]
+                if varValue != "":
                     varValue = typeCheck(varValue)
             else:
                 varName = ""
                 varValue = each_val
-                if varValue !="":
+                if varValue != "":
                     varValue = typeCheck(varValue)
 
             if isinstance(varValue, str) and "," in varValue:
-                varValue=(varValue.replace('{','').strip()).replace('}','').strip()
+                varValue = (varValue.replace('{', '').strip()).replace('}', '').strip()
                 multiple_values = varValue.split(",")
 
             for n in range(len(multiple_values)):
@@ -159,38 +162,40 @@ def make_values(strings, name):
                 each_v = typeCheck(each_v)
                 multiple_values.append(each_v)
 
-            if len(multiple_values)!=0:
-                result[main_set_name]['Elements'][name]['Properties']['Results'][varName]=multiple_values
-            elif varName !="" and varValue != "":
-                result[main_set_name]['Elements'][name]['Properties']['Results'][varName]=varValue
+            if len(multiple_values) != 0:
+                result[main_set_name]['Elements'][name]['Properties']['Results'][varName] = multiple_values
+            elif varName != "" and varValue != "":
+                result[main_set_name]['Elements'][name]['Properties']['Results'][varName] = varValue
             else:
-                if varValue!= "":
+                if varValue != "":
                     result[main_set_name]['Elements'][name]['Properties']['Values'].append(varValue)
+
 
 def delete_elements(strings):
     index = 0
     while index < len(strings):
-            character = strings[index]
-            """ handle data within the parenthesis () """
-            if character == "(":
-                    pos = index
-                    while pos > 0:
-                            char = strings[pos]
-                            if char =="":
-                                    break
-                            elif char == ",":
-                                    break
-                            elif char == " ":
-                                pos = pos+1
-                                break
-                            elif char == "{":
-                                    break
-                            pos = pos - 1
-                    delStr = strings[pos: strings.rfind(")")]
-                    strings = strings.replace(delStr,'').strip()
-                    strings = ''.join(c for c in strings if c not in '{}''()')
-            index +=1
+        character = strings[index]
+        """ handle data within the parenthesis () """
+        if character == "(":
+            pos = index
+            while pos > 0:
+                char = strings[pos]
+                if char == "":
+                    break
+                elif char == ",":
+                    break
+                elif char == " ":
+                    pos = pos + 1
+                    break
+                elif char == "{":
+                    break
+                pos = pos - 1
+            delStr = strings[pos: strings.rfind(")")]
+            strings = strings.replace(delStr, '').strip()
+            strings = ''.join(c for c in strings if c not in '{}''()')
+        index += 1
     return strings
+
 
 def make_subset_sets(strings, name):
     index = 0
@@ -199,7 +204,7 @@ def make_subset_sets(strings, name):
     subset_name = "Subset1"
     set_name = "Set1"
 
-    set_list=strings.split(",")
+    set_list = strings.split(",")
     items = []
 
     """ make the values list, first. """
@@ -212,7 +217,7 @@ def make_subset_sets(strings, name):
         """ find the highest SET number """
         for each_name in result:
             if each_name.find("SET") != -1:
-                    main_set_name = each_name
+                main_set_name = each_name
 
         """ find the highest Subset number """
         for each_name in result[main_set_name]:
@@ -223,28 +228,28 @@ def make_subset_sets(strings, name):
         """ find the highest Set number & make the next Set in Subset """
         for each_name in result[main_set_name][subset_name]:
             if each_name.find("Set") != -1:
-                the_num = each_name.replace('Set','')
+                the_num = each_name.replace('Set', '')
                 the_num = int(the_num)
                 if the_num > highest_count:
                     highest_count = the_num
-                    the_num +=1
+                    the_num += 1
                 elif highest_count > the_num:
                     the_num = highest_count + 1
                 else:
-                    the_num +=1
+                    the_num += 1
                 set_name = 'Set' + str(the_num)
 
-        result[main_set_name][subset_name]={}
-        result[main_set_name][subset_name][set_name]=[]
-        result[main_set_name][subset_name][set_name]= items
+        result[main_set_name][subset_name] = {}
+        result[main_set_name][subset_name][set_name] = []
+        result[main_set_name][subset_name][set_name] = items
 
     else:
         for each_name in result:
             if each_name.find("SET") != -1:
-                    main_set_name = each_name
+                main_set_name = each_name
 
         if "Subset1" not in result[main_set_name]['Elements'][name]['Properties']:
-            result[main_set_name]['Elements'][name]['Properties'][subset_name]={}
+            result[main_set_name]['Elements'][name]['Properties'][subset_name] = {}
 
         for each_name in result[main_set_name]['Elements'][name]['Properties']:
             if each_name.find("Subset") != -1:
@@ -253,19 +258,20 @@ def make_subset_sets(strings, name):
         highest_count = 1
         for each_name in result[main_set_name]['Elements'][name]['Properties'][subset_name]:
             if each_name.find("Set") != -1:
-                the_num = each_name.replace('Set','')
+                the_num = each_name.replace('Set', '')
                 the_num = int(the_num)
                 if the_num > highest_count:
                     highest_count = the_num
-                    the_num +=1
+                    the_num += 1
                 elif highest_count > the_num:
                     the_num = highest_count + 1
                 else:
-                    the_num +=1
+                    the_num += 1
                 set_name = 'Set' + str(the_num)
 
-        result[main_set_name]['Elements'][name]['Properties'][subset_name][set_name]=[]
-        result[main_set_name]['Elements'][name]['Properties'][subset_name][set_name]= items
+        result[main_set_name]['Elements'][name]['Properties'][subset_name][set_name] = []
+        result[main_set_name]['Elements'][name]['Properties'][subset_name][set_name] = items
+
 
 def make_sets(strings, name):
     if strings == "{}":
@@ -275,15 +281,15 @@ def make_sets(strings, name):
     main_set_name = "SET1"
     set_name = "Set1"
 
-    if strings[0]=="{" and strings[-1]=="}":
+    if strings[0] == "{" and strings[-1] == "}":
         strings = strings[1:-1]
 
-    set_list=strings.split(",")
+    set_list = strings.split(",")
     items = []
 
     for each_item in set_list:
         each_item = typeCheck(each_item)
-        if type(each_item)== str:
+        if type(each_item) == str:
             each_item = (each_item.lstrip()).rstrip()
         items.append(each_item)
 
@@ -295,36 +301,37 @@ def make_sets(strings, name):
         highest_count = 1
         for each_name in result[main_set_name]:
             if each_name.find("Set") != -1:
-                    the_num = each_name.replace('Set','')
-                    the_num = int(the_num)
-                    if the_num > highest_count:
-                        highest_count = the_num
-                        the_num +=1
-                    elif highest_count > the_num:
-                        the_num = highest_count + 1
-                    else:
-                        the_num +=1
-                    set_name = 'Set' + str(the_num)
+                the_num = each_name.replace('Set', '')
+                the_num = int(the_num)
+                if the_num > highest_count:
+                    highest_count = the_num
+                    the_num += 1
+                elif highest_count > the_num:
+                    the_num = highest_count + 1
+                else:
+                    the_num += 1
+                set_name = 'Set' + str(the_num)
 
-        result[main_set_name][set_name]=[]
-        result[main_set_name][set_name]= items
+        result[main_set_name][set_name] = []
+        result[main_set_name][set_name] = items
 
     else:
         highest_count = 1
         for each_name in result[main_set_name]['Elements'][name]['Properties']:
             if each_name.find("Set") != -1:
-                    the_num = each_name.replace('Set','')
-                    the_num = int(the_num)
-                    if the_num > highest_count:
-                        highest_count = the_num
-                        the_num +=1
-                    elif highest_count > the_num:
-                        the_num = highest_count + 1
-                    else:
-                        the_num +=1
-                    set_name = 'Set' + str(the_num)
-        result[main_set_name]['Elements'][name]['Properties'][set_name]=[]
-        result[main_set_name]['Elements'][name]['Properties'][set_name]= items
+                the_num = each_name.replace('Set', '')
+                the_num = int(the_num)
+                if the_num > highest_count:
+                    highest_count = the_num
+                    the_num += 1
+                elif highest_count > the_num:
+                    the_num = highest_count + 1
+                else:
+                    the_num += 1
+                set_name = 'Set' + str(the_num)
+        result[main_set_name]['Elements'][name]['Properties'][set_name] = []
+        result[main_set_name]['Elements'][name]['Properties'][set_name] = items
+
 
 def get_inner_sets(strings, for_this, name):
     start = 0
@@ -335,67 +342,67 @@ def get_inner_sets(strings, for_this, name):
     if "{{" in strings:
         for each_name in result:
             if each_name.find("SET") != -1:
-                    main_set_name = each_name
+                main_set_name = each_name
         if "SET" in name:
             highest_count = 1
             for each_name in result[main_set_name]:
                 if each_name.find("Subset") != -1:
-                    the_num = each_name.replace('Subset','')
+                    the_num = each_name.replace('Subset', '')
                     the_num = int(the_num)
                     if the_num > highest_count:
                         highest_count = the_num
-                        the_num +=1
+                        the_num += 1
                     elif highest_count > the_num:
                         the_num = highest_count + 1
                     else:
-                        the_num +=1
+                        the_num += 1
                     subset_name = subset_name + str(the_num)
-            result[main_set_name][subset_name]={}
+            result[main_set_name][subset_name] = {}
         else:
             highest_count = 1
             for each_name in result[main_set_name]['Elements'][name]['Properties']:
                 if each_name.find("Subset") != -1:
-                    the_num = each_name.replace('Subset','')
+                    the_num = each_name.replace('Subset', '')
                     the_num = int(the_num)
                     if the_num > highest_count:
                         highest_count = the_num
-                        the_num +=1
+                        the_num += 1
                     elif highest_count > the_num:
                         the_num = highest_count + 1
                     else:
-                        the_num +=1
+                        the_num += 1
                     subset_name = "Subset" + str(the_num)
-            result[main_set_name]['Elements'][name]['Properties'][subset_name]={}
+            result[main_set_name]['Elements'][name]['Properties'][subset_name] = {}
 
         start = strings.find("{{")
         end = strings.find("}}")
-        sets = strings[start+1:end+1]
+        sets = strings[start + 1:end + 1]
         index = 0
         while index < len(sets):
             inner_set_start = sets.find("{")
-            if inner_set_start !=-1:
+            if inner_set_start != -1:
                 inner_set_end = sets.find("}")
-                inner_set = sets[inner_set_start:inner_set_end+1]
+                inner_set = sets[inner_set_start:inner_set_end + 1]
                 sets = sets.replace(inner_set, '')
                 index = 0
-                make_subset_sets(inner_set,name)
-            index +=1
+                make_subset_sets(inner_set, name)
+            index += 1
     elif "{" in strings:
         position = 0
         b_count = 0
         while position < len(strings):
             character = strings[position]
             if character == "{":
-                b_count +=1
-                if b_count ==1:
+                b_count += 1
+                if b_count == 1:
                     mark_start = position
             elif character == "}":
-                b_count -=1
-                if b_count ==0:
-                    mark_end = position +1
+                b_count -= 1
+                if b_count == 0:
+                    mark_end = position + 1
                     sets = strings[mark_start:mark_end]
-                    make_sets(sets,name)
-            position +=1
+                    make_sets(sets, name)
+            position += 1
 
 
 def make_elements(strings):
@@ -406,19 +413,19 @@ def make_elements(strings):
     while index < len(strings):
         character = strings[index]
         if character == "(":
-            pos = index-1
+            pos = index - 1
             while pos > 0:
                 char = strings[pos]
                 if char.isalnum():
                     begin = pos
-                    pos = pos-1
+                    pos = pos - 1
                 else:
                     break
 
             name = strings[begin:index]
             index = pos
             original_name = name
-            name = name +str(1)
+            name = name + str(1)
 
             for each_name in result:
                 if each_name.find("SET") != -1:
@@ -427,55 +434,55 @@ def make_elements(strings):
             highest_count = 1
             for each_name in result[main_set_name]['Elements']:
                 if original_name in each_name:
-                    the_num = each_name.replace(original_name,'')
+                    the_num = each_name.replace(original_name, '')
                     the_num = int(the_num)
                     if the_num > highest_count:
                         highest_count = the_num
-                        the_num +=1
+                        the_num += 1
                     elif highest_count > the_num:
                         the_num = highest_count + 1
                     else:
-                        the_num +=1
+                        the_num += 1
                     name = original_name + str(the_num)
 
-            result[main_set_name]['Elements'][name]={}
-            result[main_set_name]['Elements'][name]['Properties']={}
+            result[main_set_name]['Elements'][name] = {}
+            result[main_set_name]['Elements'][name]['Properties'] = {}
 
             brace_count = 0
 
             skip_brace = 0
             while index < len(strings):
                 character = strings[index]
-                if character =="(":
-                    brace_count +=1
+                if character == "(":
+                    brace_count += 1
                     if brace_count == 1:
                         mark_start = index
-                elif character ==")":
-                    brace_count -=1
-                    mark_end = index+1
-                    if brace_count ==0:
-                        mark_end = index+1
-                        index +=1
+                elif character == ")":
+                    brace_count -= 1
+                    mark_end = index + 1
+                    if brace_count == 0:
+                        mark_end = index + 1
+                        index += 1
                         break
                 elif character == "=":
-                    skip_start = index+1
+                    skip_start = index + 1
                     if strings[skip_start] == "{":
                         skip_brace += 1
                         indx = skip_start
                         while indx < len(strings):
                             char = strings[indx]
                             if char == "}":
-                                skip_brace -=1
-                                if skip_brace ==0:
-                                    index = indx+1
+                                skip_brace -= 1
+                                if skip_brace == 0:
+                                    index = indx + 1
                                     break
-                            indx +=1
+                            indx += 1
 
-                index +=1
+                index += 1
 
             element_str = strings[mark_start:mark_end]
             del_element_str = original_name + element_str
-            strings = strings.replace(del_element_str,'').strip()
+            strings = strings.replace(del_element_str, '').strip()
 
             index = 0
             start = 0
@@ -483,36 +490,37 @@ def make_elements(strings):
             position = 0
             while position < len(element_str):
                 char = element_str[position]
-                if char == "{" and element_str[position +1] == "{":
-                    start = position-1
+                if char == "{" and element_str[position + 1] == "{":
+                    start = position - 1
                     end = element_str.find("}}")
-                    sets = element_str[start:end+2]
+                    sets = element_str[start:end + 2]
                     position = position + len(sets)
-                    element_str = element_str.replace(sets,'')
+                    element_str = element_str.replace(sets, '')
                     position = 0
-                    if len(sets)>1:
-                        get_inner_sets(sets,"Subset",name)
+                    if len(sets) > 1:
+                        get_inner_sets(sets, "Subset", name)
                 elif char == "{":
                     start = position
                     end = element_str.find("}")
-                    sets = element_str[start:end+1]
+                    sets = element_str[start:end + 1]
 
                     i = start
                     while i > 0:
                         text = element_str[i]
                         if text == ",":
-                            name_start = i+1
+                            name_start = i + 1
                             break
-                        i -=1
+                        i -= 1
                     name_of_set = element_str[name_start:start]
-                    if name_of_set.find("=") ==-1:
-                        element_str = element_str.replace(element_str[start:end+1], '').strip()
+                    if name_of_set.find("=") == -1:
+                        element_str = element_str.replace(element_str[start:end + 1], '').strip()
                         position = 0
-                        if len(sets)>1:
-                            get_inner_sets(sets,"Set",name)
+                        if len(sets) > 1:
+                            get_inner_sets(sets, "Set", name)
                 position += 1
             make_values(element_str, name)
-        index +=1
+        index += 1
+
 
 def check_for_next_string(next_string):
     anchorr = 0
@@ -520,26 +528,27 @@ def check_for_next_string(next_string):
     stopp = 0
 
     """ remove braces & keep only the SET's values. """
-    while positionn <len(next_string):
+    while positionn < len(next_string):
         check_str = next_string[positionn]
         if check_str == "{":
-                anchorr = positionn
+            anchorr = positionn
         elif check_str == "}":
-                stopp = positionn
-                delStr = next_string[anchorr:stopp+1]
-                next_string = next_string.replace(delStr,'')
-                positionn = -1
-        positionn +=1
+            stopp = positionn
+            delStr = next_string[anchorr:stopp + 1]
+            next_string = next_string.replace(delStr, '')
+            positionn = -1
+        positionn += 1
 
         if type(next_string) is str:
             if len(next_string) == 0:
                 next_set = ""
                 return next_set
 
+
 def get_the_set(string):
 
     def skip_all_inner_sets(position):
-        position +=1
+        position += 1
         count = 1
         main_count = 1
         max_count = main_count
@@ -551,43 +560,43 @@ def get_the_set(string):
         while pos < len(string):
             charac = string[pos]
             if charac == "{":
-                count +=1
+                count += 1
                 max_count = count
             elif charac == "}":
-                count -=1
+                count -= 1
                 if count == 0:
                     end_of_main_set = pos
                     break
-            pos +=1
-        if count !=0:
-            print ("\nParser Error: Are you missing one or more '}'s? \n")
+            pos += 1
+        if count != 0:
+            print("\nParser Error: Are you missing one or more '}'s? \n")
             sys.exit(1)
 
         if max_count >= 2:
             while position < end_of_main_set:
                 brace_count = 0
                 char = string[position]
-                if char == "{" and string[position+1]!="{":
+                if char == "{" and string[position + 1] != "{":
                     start = position
-                    main_count +=1
-                    if main_count >=2:
+                    main_count += 1
+                    if main_count >= 2:
                         mark_index = position
 
                     b_count = 0
                     while position < len(string):
                         ch = string[position]
                         if ch == "{":
-                            main_count +=1
-                            b_count +=1
+                            main_count += 1
+                            b_count += 1
                         elif ch == "}":
-                            b_count -=1
-                            if b_count ==0:
-                                if main_count <=2:
-                                    skip = position+1
+                            b_count -= 1
+                            if b_count == 0:
+                                if main_count <= 2:
+                                    skip = position + 1
                                     last_set = skip
                                     inner_sets.append(string[start:skip])
                                 elif main_count > 2:
-                                    skip = position+1
+                                    skip = position + 1
                                     last_set = skip
                                     position = skip
                                     next_set_list.append(string[mark_index:skip])
@@ -597,149 +606,149 @@ def get_the_set(string):
                                         next_set[0] = next_set[0] + string[mark_index:skip]
                                 break
                         elif ch == "(":
-                            brace_count +=1
+                            brace_count += 1
                             brace_start = position
-                            position +=1
+                            position += 1
                             while position < end_of_main_set:
                                 s = string[position]
                                 if s == "(":
-                                    brace_count +=1
+                                    brace_count += 1
                                 elif s == ")":
-                                    brace_count -=1
-                                    if brace_count ==0:
+                                    brace_count -= 1
+                                    if brace_count == 0:
                                         last_brace = position
                                         break
-                                elif s == "=" and string[position+1]=="{":
-                                    indx = position+2
+                                elif s == "=" and string[position + 1] == "{":
+                                    indx = position + 2
                                     skip_brace = 1
                                     while indx < end_of_main_set:
                                         char = string[indx]
                                         if char == "}":
-                                            skip_brace -=1
-                                            if skip_brace ==0:
-                                                position = indx+1
+                                            skip_brace -= 1
+                                            if skip_brace == 0:
+                                                position = indx + 1
                                                 break
-                                        indx +=1
-                                position +=1
-                        position +=1
-                elif char == "{" and string[position+1]=="{":
+                                        indx += 1
+                                position += 1
+                        position += 1
+                elif char == "{" and string[position + 1] == "{":
                     start = position
-                    main_count +=1
+                    main_count += 1
                     if main_count >= 2:
-                                mark_index = position
-                    position +=1
+                        mark_index = position
+                    position += 1
                     b_count = 1
 
                     while position < len(string):
                         ch = string[position]
                         if ch == "{":
-                            main_count +=1
-                            b_count +=1
+                            main_count += 1
+                            b_count += 1
                         elif ch == "}":
-                            b_count -=1
-                            if b_count ==0:
-                                if main_count <=3:
-                                    skip = position+1
+                            b_count -= 1
+                            if b_count == 0:
+                                if main_count <= 3:
+                                    skip = position + 1
                                     last_subset = skip
                                     inner_sets.append(string[start:skip])
                                 elif main_count > 3:
-                                    skip = position+1
+                                    skip = position + 1
                                     last_subset = skip
                                     position = skip
                                     next_set_list.append(string[mark_index:skip])
                                     if next_set[0] == '':
-                                        next_set[0]=string[mark_index:skip]
+                                        next_set[0] = string[mark_index:skip]
                                     else:
                                         next_set[0] = next_set[0] + string[mark_index:skip]
                                 break
                         elif ch == "(":
-                            brace_count +=1
+                            brace_count += 1
                             brace_start = position
-                            position +=1
+                            position += 1
                             while position < end_of_main_set:
                                 s = string[position]
                                 if s == "(":
-                                    brace_count +=1
+                                    brace_count += 1
                                 elif s == ")":
-                                    brace_count -=1
-                                    if brace_count ==0:
+                                    brace_count -= 1
+                                    if brace_count == 0:
                                         last_brace = position
                                         break
-                                position +=1
-                        position +=1
+                                position += 1
+                        position += 1
                 elif char == "(":
-                    brace_count +=1
+                    brace_count += 1
                     brace_start = position
-                    position +=1
+                    position += 1
                     while position < end_of_main_set:
                         s = string[position]
                         if s == "(":
-                            brace_count +=1
+                            brace_count += 1
                         elif s == ")":
-                            brace_count -=1
-                            if brace_count ==0:
+                            brace_count -= 1
+                            if brace_count == 0:
                                 last_brace = position
                                 break
-                        position +=1
+                        position += 1
 
-                position +=1
+                position += 1
         else:
             next_set[0] = ""
-            return (len(string)-1)
+            return (len(string) - 1)
 
-        max_of_sets = max(last_set,last_subset)
+        max_of_sets = max(last_set, last_subset)
         max_of_main_set = max(max_of_sets, last_subset)
 
-        if max_of_main_set !=0:
+        if max_of_main_set != 0:
             return max_of_main_set
         else:
-            return (len(string)-1)
+            return (len(string) - 1)
 
     """ Main entry of get_the_string() """
     index = 0
     count = 0
     next_set[0] = ''
-    inner_sets =[]
-    next_set_list =[]
+    inner_sets = []
+    next_set_list = []
     end = len(string)
 
     if "{" and "}" in string:
         while index < len(string):
             character = string[index]
             if character == "{":
-                count +=1
-                if count ==1:
+                count += 1
+                if count == 1:
                     anchor = index
                 index = skip_all_inner_sets(index)
-                if index == (len(string)-1):
-                    if string[index]=="}":
-                        count -=1
+                if index == (len(string) - 1):
+                    if string[index] == "}":
+                        count -= 1
                         end = index
             elif character == "}":
-                count -=1
-                if count ==0:
+                count -= 1
+                if count == 0:
                     end = index
-            index +=1
-        main_set = string[anchor:end+1]
+            index += 1
+        main_set = string[anchor:end + 1]
         current_set = main_set
 
-        if next_set[0] !="":
+        if next_set[0] != "":
             for each_next in next_set_list:
-                current_set = current_set.replace(each_next,'').strip()
+                current_set = current_set.replace(each_next, '').strip()
 
             pos = 0
             """ remove unwanted commas from CS """
             while pos < len(current_set):
                 char = current_set[pos]
                 if char == ",":
-                    if current_set[pos+1]=="}":
-                        current_set =current_set[0:pos]+current_set[pos+1:(len(current_set))]
+                    if current_set[pos + 1] == "}":
+                        current_set = current_set[0:pos] + current_set[pos + 1:(len(current_set))]
                         pos = 0
-                pos +=1
+                pos += 1
 
             check_string = ''.join(e for e in current_set if e.isalnum())
 
-            if len(check_string)>0:
+            if len(check_string) > 0:
                 return current_set, next_set[0]
             else:
                 current_set = ""
@@ -747,85 +756,91 @@ def get_the_set(string):
         else:
             return current_set, next_set[0]
     else:
-        print ("\nThe following String has no {}s to proceed\n")
-        print (string)
+        print("\nThe following String has no {}s to proceed\n")
+        print(string)
 
     """ End of get_the_string() """
 
 # String parsing function for SimulationResults
+
+
 def formatSimRes(strings):
     result['SimulationResults'] = {}
-    simRes = strings[strings.find('  resultFile')+1:strings.find('\nend SimulationResult')]
+    simRes = strings[strings.find('  resultFile') + 1:strings.find('\nend SimulationResult')]
     simRes = simRes.translate(None, "\\")
     simRes = simRes.split('\n')
     simOps = simRes.pop(1)
-    options = simOps[simOps.find('"startTime')+1:simOps.find('",')]
-    options = options+","
+    options = simOps[simOps.find('"startTime') + 1:simOps.find('",')]
+    options = options + ","
     index = 0
     anchor = 0
 
     for i in simRes:
-            var = i[i.find('')+1:i.find(" =")]
-            var = (var.lstrip()).rstrip()
-            value = i[i.find("= ")+1:i.find(",")]
-            value = (value.lstrip()).rstrip()
-            value = typeCheck(value)
-            result['SimulationResults'][var] = value
+        var = i[i.find('') + 1:i.find(" =")]
+        var = (var.lstrip()).rstrip()
+        value = i[i.find("= ") + 1:i.find(",")]
+        value = (value.lstrip()).rstrip()
+        value = typeCheck(value)
+        result['SimulationResults'][var] = value
 
-    result['SimulationOptions']={}
+    result['SimulationOptions'] = {}
 
     while index < len(options):
+        update = False
+        character = options[index]
+        if character == "=":
+            opVar = options[anchor:index]
+            opVar = (opVar.lstrip()).rstrip()
+            anchor = index + 1
             update = False
-            character = options[index]
-            if character == "=":
-                    opVar = options[anchor:index]
-                    opVar = (opVar.lstrip()).rstrip()
-                    anchor = index+1
-                    update = False
-            elif character == ",":
-                    opVal = options[anchor:index]
-                    opVal = (opVal.lstrip()).rstrip()
-                    anchor = index+1
-                    update = True
-            index = index + 1
-            if update:
-                    opVal = typeCheck(opVal)
-                    result['SimulationOptions'][opVar] = opVal
+        elif character == ",":
+            opVal = options[anchor:index]
+            opVal = (opVal.lstrip()).rstrip()
+            anchor = index + 1
+            update = True
+        index = index + 1
+        if update:
+            opVal = typeCheck(opVal)
+            result['SimulationOptions'][opVar] = opVal
 
 # string parsing function for Record types
+
+
 def formatRecords(strings):
     result['RecordResults'] = {}
-    recordName = strings[strings.find("record ") +1:strings.find("\n")]
-    recordName = recordName.replace("ecord ",'').strip()
-    strings = strings.replace(("end "+recordName+";"),'').strip()
-    recordItems = strings[strings.find("\n") +1: len(strings)]
-    recordItems = recordItems.translate(None,"\\")
+    recordName = strings[strings.find("record ") + 1:strings.find("\n")]
+    recordName = recordName.replace("ecord ", '').strip()
+    strings = strings.replace(("end " + recordName + ";"), '').strip()
+    recordItems = strings[strings.find("\n") + 1: len(strings)]
+    recordItems = recordItems.translate(None, "\\")
     recordItems = recordItems.split("\n")
     for each_item in recordItems:
-        var = each_item[each_item.find('')+1:each_item.find(" =")]
+        var = each_item[each_item.find('') + 1:each_item.find(" =")]
         var = (var.lstrip()).rstrip()
-        value = each_item[each_item.find("= ")+1:each_item.find(",")]
+        value = each_item[each_item.find("= ") + 1:each_item.find(",")]
         value = (value.lstrip()).rstrip()
         value = typeCheck(value)
         if var != "":
             result['RecordResults'][var] = value
     result['RecordResults']['RecordName'] = recordName
 
+
 """ Main entry to the OMParser module """
+
+
 def check_for_values(string):
     main_set_name = "SET1"
-    if len(string)==0:
+    if len(string) == 0:
         return result
 
     """changing untyped results to typed results"""
-    if string[0]=="(":
-        string = "{"+string[1:-2]+"}"
+    if string[0] == "(":
+        string = "{" + string[1:-2] + "}"
 
-
-    if string[0]== "\"":
-        string = string.replace("\\\"","\"")
-        string = string.replace("\\?","?")
-        string = string.replace("\\'","'")
+    if string[0] == "\"":
+        string = string.replace("\\\"", "\"")
+        string = string.replace("\\?", "?")
+        string = string.replace("\\'", "'")
         return string
 
     if "record SimulationResult" in string:
@@ -835,54 +850,53 @@ def check_for_values(string):
         formatRecords(string)
         return result
 
-    string=typeCheck(string)
+    string = typeCheck(string)
 
     if type(string) is not str:
         return string
-    elif string.find("{")==-1:
+    elif string.find("{") == -1:
         return string
 
-    current_set,next_set = get_the_set(string)
+    current_set, next_set = get_the_set(string)
 
     for each_name in result:
         if each_name.find("SET") != -1:
-            the_num = each_name.replace("SET",'')
+            the_num = each_name.replace("SET", '')
             the_num = int(the_num)
             the_num = the_num + 1
             main_set_name = "SET" + str(the_num)
 
-    result[main_set_name]={}
+    result[main_set_name] = {}
 
-    if current_set !="":
-        if current_set[1]=="\"" and current_set[-2]=="\"":
-            make_values(current_set,"SET")
+    if current_set != "":
+        if current_set[1] == "\"" and current_set[-2] == "\"":
+            make_values(current_set, "SET")
             current_set = ""
             check_for_next_iteration = ''.join(e for e in next_set if e.isalnum())
-            if len(check_for_next_iteration)>0:
+            if len(check_for_next_iteration) > 0:
                 check_for_values(next_set)
 
         elif "(" in current_set:
             for each_name in result:
                 if each_name.find("SET") != -1:
                     main_set_name = each_name
-            result[main_set_name]['Elements']={}
+            result[main_set_name]['Elements'] = {}
 
             make_elements(current_set)
             current_set = delete_elements(current_set)
 
     if "{{" in current_set:
-        get_inner_sets(current_set,"Subset", main_set_name)
+        get_inner_sets(current_set, "Subset", main_set_name)
 
     if "{" in current_set:
-        get_inner_sets(current_set,"Set", main_set_name)
-
+        get_inner_sets(current_set, "Set", main_set_name)
 
     check_for_next_iteration = ''.join(e for e in next_set if e not in {""})
-    if len(check_for_next_iteration)>0:
+    if len(check_for_next_iteration) > 0:
         check_for_values(next_set)
     else:
         check_for_next_iteration = ''.join(e for e in next_set if e.isalnum())
-        if len(check_for_next_iteration)>0:
+        if len(check_for_next_iteration) > 0:
             check_for_values(next_set)
 
     return result

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -100,6 +100,8 @@ logger_console_handler.setFormatter(logger_formatter)
 logger.addHandler(logger_console_handler)
 
 import abc
+
+
 class OMCSessionBase(object):
     __metaclass__ = abc.ABCMeta
 
@@ -125,22 +127,22 @@ class OMCSessionBase(object):
 
     def _create_omc_log_file(self, suffix):
         if sys.platform == 'win32':
-          self._omc_log_file = open(os.path.join(self._temp_dir, "openmodelica.{0}.{1}.log".format(suffix, self._random_string)), 'w')
+            self._omc_log_file = open(os.path.join(self._temp_dir, "openmodelica.{0}.{1}.log".format(suffix, self._random_string)), 'w')
         else:
-          self._currentUser = getpass.getuser()
-          if not self._currentUser:
-              self._currentUser = "nobody"
-          # this file must be closed in the destructor
-          self._omc_log_file = open(os.path.join(self._temp_dir, "openmodelica.{0}.{1}.{2}.log".format(self._currentUser, suffix, self._random_string)), 'w')
+            self._currentUser = getpass.getuser()
+            if not self._currentUser:
+                self._currentUser = "nobody"
+            # this file must be closed in the destructor
+            self._omc_log_file = open(os.path.join(self._temp_dir, "openmodelica.{0}.{1}.{2}.log".format(self._currentUser, suffix, self._random_string)), 'w')
 
     def _start_omc_process(self):
         if sys.platform == 'win32':
-           omhome_bin = os.path.join(self.omhome, 'bin').replace("\\","/")
-           my_env = os.environ.copy()
-           my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
-           self._omc_process = subprocess.Popen(self._omc_command, shell=True, stdout=self._omc_log_file, stderr=self._omc_log_file, env=my_env)
+            omhome_bin = os.path.join(self.omhome, 'bin').replace("\\", "/")
+            my_env = os.environ.copy()
+            my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
+            self._omc_process = subprocess.Popen(self._omc_command, shell=True, stdout=self._omc_log_file, stderr=self._omc_log_file, env=my_env)
         else:
-           self._omc_process = subprocess.Popen(self._omc_command, shell=True, stdout=self._omc_log_file, stderr=self._omc_log_file)
+            self._omc_process = subprocess.Popen(self._omc_command, shell=True, stdout=self._omc_log_file, stderr=self._omc_log_file)
         return self._omc_process
 
     def _set_omc_command(self, omc_path, args):
@@ -151,13 +153,13 @@ class OMCSessionBase(object):
         try:
             self.omhome = os.environ.get('OPENMODELICAHOME')
             if self.omhome is None:
-              self.omhome = os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
+                self.omhome = os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
             elif os.path.exists('/opt/local/bin/omc'):
-              self.omhome = '/opt/local'
+                self.omhome = '/opt/local'
             return os.path.join(self.omhome, 'bin', 'omc')
         except:
-          logger.error("The OpenModelica compiler is missing in the System path (%s), please install it" % os.path.join(self.omhome, 'bin', 'omc'))
-          raise
+            logger.error("The OpenModelica compiler is missing in the System path (%s), please install it" % os.path.join(self.omhome, 'bin', 'omc'))
+            raise
 
     @abc.abstractmethod
     def _connect_to_omc(self):
@@ -368,7 +370,7 @@ class OMCSessionBase(object):
         value = self.ask('getNthComponentModification', '{0}, {1}'.format(className, comp_id), parsed=False)
         value = value.replace("{$Code(", "")
         return value[:-3]
-        #return self.re_Code.findall(value)
+        # return self.re_Code.findall(value)
 
     # function getClassNames
     #   input TypeName class_ = $Code(AllLoadedClasses);
@@ -392,6 +394,7 @@ class OMCSessionBase(object):
                                  str(recursive).lower(), str(qualified).lower(), str(sort).lower(),
                                  str(builtin).lower(), str(showProtected).lower()))
         return value
+
 
 class OMCSession(OMCSessionBase):
 
@@ -419,7 +422,7 @@ class OMCSession(OMCSessionBase):
             self._ior_file = "openmodelica.objid." + self._random_string
         else:
             self._ior_file = "openmodelica." + self._currentUser + ".objid." + self._random_string
-        self._ior_file = os.path.join(self._temp_dir, self._ior_file).replace("\\","/")
+        self._ior_file = os.path.join(self._temp_dir, self._ior_file).replace("\\", "/")
         self._omc_corba_uri = "file:///" + self._ior_file
         # See if the omc server is running
         if os.path.isfile(self._ior_file):
@@ -441,7 +444,7 @@ class OMCSession(OMCSessionBase):
                     logger.info("OMC Server is up and running at {0}".format(self._omc_corba_uri))
                     break
 
-        #initialize the ORB with maximum size for the ORB set
+        # initialize the ORB with maximum size for the ORB set
         sys.argv.append("-ORBgiopMaxMsgSize")
         sys.argv.append("2147483647")
         self._orb = CORBA.ORB_init(sys.argv, CORBA.ORB_ID)
@@ -462,30 +465,31 @@ class OMCSession(OMCSessionBase):
 
     def execute(self, command):
         if self._omc is not None:
-          result = self._omc.sendExpression(command)
-          if command == "quit()":
-            self._omc = None
-            return result
-          else:
-            answer = OMParser.check_for_values(result)
-            return answer
+            result = self._omc.sendExpression(command)
+            if command == "quit()":
+                self._omc = None
+                return result
+            else:
+                answer = OMParser.check_for_values(result)
+                return answer
         else:
-          return "No connection with OMC. Create an instance of OMCSession."
+            return "No connection with OMC. Create an instance of OMCSession."
 
     def sendExpression(self, command, parsed=True):
         if self._omc is not None:
-          result = self._omc.sendExpression(str(command))
-          if command == "quit()":
-            self._omc = None
-            return result
-          else:
-            if (parsed==True):
-               answer = OMTypedParser.parseString(result)
-               return answer
+            result = self._omc.sendExpression(str(command))
+            if command == "quit()":
+                self._omc = None
+                return result
             else:
-               return result
+                if (parsed == True):
+                    answer = OMTypedParser.parseString(result)
+                    return answer
+                else:
+                    return result
         else:
-          return "No connection with OMC. Create an instance of OMCSession."
+            return "No connection with OMC. Create an instance of OMCSession."
+
 
 class OMCSessionZMQ(OMCSessionBase):
 
@@ -508,7 +512,7 @@ class OMCSessionZMQ(OMCSessionBase):
             self._port_file = "openmodelica.port." + self._random_string
         else:
             self._port_file = "openmodelica." + self._currentUser + ".port." + self._random_string
-        self._port_file = os.path.join(self._temp_dir, self._port_file).replace("\\","/")
+        self._port_file = os.path.join(self._temp_dir, self._port_file).replace("\\", "/")
         self._omc_zeromq_uri = "file:///" + self._port_file
         # See if the omc server is running
         if os.path.isfile(self._port_file):
@@ -542,43 +546,45 @@ class OMCSessionZMQ(OMCSessionBase):
 
     def execute(self, command):
         if self._omc is not None:
-          self._omc.send_string(command)
-          result = self._omc.recv_string()
-          if command == "quit()":
-            self._omc.close()
-            self._omc = None
-            return result
-          else:
-            answer = OMParser.check_for_values(result)
-            return answer
+            self._omc.send_string(command)
+            result = self._omc.recv_string()
+            if command == "quit()":
+                self._omc.close()
+                self._omc = None
+                return result
+            else:
+                answer = OMParser.check_for_values(result)
+                return answer
         else:
-          return "No connection with OMC. Create an instance of OMCSessionZMQ."
+            return "No connection with OMC. Create an instance of OMCSessionZMQ."
 
     def sendExpression(self, command, parsed=True):
         if self._omc is not None:
-          self._omc.send_string(str(command))
-          result = self._omc.recv_string()
-          if command == "quit()":
-            self._omc.close()
-            self._omc = None
-            return result
-          else:
-            if (parsed==True):
-               answer = OMTypedParser.parseString(result)
-               return answer
+            self._omc.send_string(str(command))
+            result = self._omc.recv_string()
+            if command == "quit()":
+                self._omc.close()
+                self._omc = None
+                return result
             else:
-               return result
+                if (parsed == True):
+                    answer = OMTypedParser.parseString(result)
+                    return answer
+                else:
+                    return result
         else:
-          return "No connection with OMC. Create an instance of OMCSessionZMQ."
+            return "No connection with OMC. Create an instance of OMCSessionZMQ."
 
-#author = Sudeep Bajracharya
-#sudba156@student.liu.se
-#LIU(Department of Computer Science)
+# author = Sudeep Bajracharya
+# sudba156@student.liu.se
+# LIU(Department of Computer Science)
+
 
 class Quantity:
     """
     To represent quantities details
     """
+
     def __init__(self, name, start, changable, variability, description, causality, alias, aliasvariable):
         self.name = name
         self.start = start
@@ -590,9 +596,8 @@ class Quantity:
         self.aliasvariable = aliasvariable
 
 
-
 class ModelicaSystem(object):
-    def __init__(self, fileName = None, modelName = None, lmodel = None, useCorba = False): #1
+    def __init__(self, fileName=None, modelName=None, lmodel=None, useCorba=False):  # 1
         """
         "constructor"
         It initializes to load file and build a model, generating object, exe, xml, mat, and json files. etc. It can be called :
@@ -603,7 +608,7 @@ class ModelicaSystem(object):
         ex: myModel = ModelicaSystem("ModelicaModel.mo", "modelName")
         """
 
-        if fileName is None and modelName is None and lmodel is None: # all None
+        if fileName is None and modelName is None and lmodel is None:  # all None
             if useCorba:
                 self.getconn = OMCSession()
             else:
@@ -614,73 +619,73 @@ class ModelicaSystem(object):
             return "File does not exist"
         self.tree = None
 
-        self.linearquantitiesList=[] #linearization  quantity list
-        self.linearinputs=[] #linearization input list
-        self.linearoutputs=[] #linearization output list
-        self.linearstates=[] #linearization  states list
-        self.quantitiesList = [] #detail list of all Modelica quantity variables inc. name, changable, description, etc
-        self.qNamesList = [] #for all quantities name list
-        self.cNamesList = [] #for continuous quantities name list
-        self.cValuesList = [] #for continuous quantities value list
-        self.iNamesList = [] #for input quantities name list
-        self.inputsVal = [] #for input quantities value list
+        self.linearquantitiesList = []  # linearization  quantity list
+        self.linearinputs = []  # linearization input list
+        self.linearoutputs = []  # linearization output list
+        self.linearstates = []  # linearization  states list
+        self.quantitiesList = []  # detail list of all Modelica quantity variables inc. name, changable, description, etc
+        self.qNamesList = []  # for all quantities name list
+        self.cNamesList = []  # for continuous quantities name list
+        self.cValuesList = []  # for continuous quantities value list
+        self.iNamesList = []  # for input quantities name list
+        self.inputsVal = []  # for input quantities value list
         self.specialNames = []
-        self.oNamesList = [] #for output quantities name list
-        self.pNamesList = [] #for parameter quantities name list
-        self.pValuesList = [] #for parameter quantities value list
-        self.oValuesList = [] #for output quantities value list
-        self.simNamesList = ['startTime', 'stopTime', 'stepSize', 'tolerance', 'solver'] #simulation options list
-        self.simValuesList = [] #for simulation values list
+        self.oNamesList = []  # for output quantities name list
+        self.pNamesList = []  # for parameter quantities name list
+        self.pValuesList = []  # for parameter quantities value list
+        self.oValuesList = []  # for output quantities value list
+        self.simNamesList = ['startTime', 'stopTime', 'stepSize', 'tolerance', 'solver']  # simulation options list
+        self.simValuesList = []  # for simulation values list
         self.optimizeOptionsNamesList = ['startTime', 'stopTime', 'numberOfIntervals', 'stepSize', 'tolerance']
-        self.optimizeOptionsValuesList = [0.0, 1.0, 500, 0.002,1e-8]
+        self.optimizeOptionsValuesList = [0.0, 1.0, 500, 0.002, 1e-8]
         self.linearizeOptionsNamesList = ['startTime', 'stopTime', 'numberOfIntervals', 'stepSize', 'tolerance']
-        self.linearizeOptionsValuesList = [0.0, 1.0, 500, 0.002,1e-8]
+        self.linearizeOptionsValuesList = [0.0, 1.0, 500, 0.002, 1e-8]
         if useCorba:
             self.getconn = OMCSession()
         else:
             self.getconn = OMCSessionZMQ()
         self.xmlFile = None
-        self.lmodel = lmodel #may be needed if model is derived from other model
-        self.modelName = modelName #Model class name
-        self.fileName = fileName #Model file/package name
-        self.inputFlag = False #for model with input quantity
-        self.simulationFlag = False #if the model is simulated?
+        self.lmodel = lmodel  # may be needed if model is derived from other model
+        self.modelName = modelName  # Model class name
+        self.fileName = fileName  # Model file/package name
+        self.inputFlag = False  # for model with input quantity
+        self.simulationFlag = False  # if the model is simulated?
         self.linearizationFlag = False
         self.outputFlag = False
-        self.csvFile = '' #for storing inputs condition
-        if not os.path.exists(self.fileName): #if file does not eixt
-            print ("File Error:"+os.path.abspath(self.fileName)+ " does not exist!!!")
+        self.csvFile = ''  # for storing inputs condition
+        if not os.path.exists(self.fileName):  # if file does not eixt
+            print("File Error:" + os.path.abspath(self.fileName) + " does not exist!!!")
             return
 
-        (head, tail) = os.path.split(self.fileName)#to store directory/path and file)
+        (head, tail) = os.path.split(self.fileName)  # to store directory/path and file)
         self.currDir = os.getcwd()
         self.modelDir = head
         self.fileName_ = tail
 
         if not self.modelDir:
             file_ = os.path.exists(self.fileName_)
-            if(file_):#execution from path where file is located
+            if(file_):  # execution from path where file is located
                 self.__loadingModel(self.fileName_, self.modelName, self.lmodel)
             else:
-                print ("Error: File does not exist!!!")
+                print("Error: File does not exist!!!")
 
         else:
             os.chdir(self.modelDir)
             file_ = os.path.exists(self.fileName_)
             self.model = self.fileName_[:-3]
-            if(self.fileName_):#execution from different path
+            if(self.fileName_):  # execution from different path
                 os.chdir(self.currDir)
                 self.__loadingModel(self.fileName, self.modelName, self.lmodel)
             else:
-                print ("Error: File does not exist!!!")
+                print("Error: File does not exist!!!")
 
     def __del__(self):
         if self.getconn is not None:
             self.requestApi('quit')
 
-    #for loading file/package, loading model and building model
+    # for loading file/package, loading model and building model
     def __loadingModel(self, fName, mName, lmodel):
-        #load file
+        # load file
         loadfileError = ''
         loadfileResult = self.requestApi("loadFile", fName)
         loadfileError = self.requestApi("getErrorString")
@@ -690,16 +695,16 @@ class ModelicaSystem(object):
                 self.requestApi("setCommandLineOptions", '"+g=Optimica"')
                 self.requestApi("loadFile", fName)
             else:
-                print ('loadFile Error: ' + loadfileError)
+                print('loadFile Error: ' + loadfileError)
                 return
 
-        #load Modelica standard libraries if needed
+        # load Modelica standard libraries if needed
         if lmodel is not None:
             loadmodelError = ''
             loadModelResult = self.requestApi("loadModel", lmodel)
             loadmodelError = self.requestApi('getErrorString')
             if loadmodelError:
-                print (loadmodelError)
+                print(loadmodelError)
                 return
 
         # build model
@@ -710,28 +715,27 @@ class ModelicaSystem(object):
         buildModelError = self.requestApi("getErrorString")
 
         if ('' in buildModelResult):
-            print (buildModelError)
+            print(buildModelError)
             return
 
         self.xmlFile = buildModelResult[1]
         self.tree = ET.parse(self.xmlFile)
         self.root = self.tree.getroot()
-        self.__createQuantitiesList() #initialize quantitiesList
-        self.__getQuantitiesNames() #initialize qNamesList
-        self.__getContinuousNames() #initialize cNamesList
-        self.__getParameterNames() #initialize pNamesList
-        self.__getInputNames() #initialize iNamesList
-        self.__setInputSize() #defing input value list size
-        self.__getOutputNames() #initialize oNamesList
-        self.__getContinuousValues() #initialize cValuesList
-        self.__getParameterValues() #initialize pValuesList
-        self.__getInputValues() #initialize input value list
-        self.__getOutputValues() #initialize oValuesList
-        self.__getSimulationValues() #initialize simulation value list
+        self.__createQuantitiesList()  # initialize quantitiesList
+        self.__getQuantitiesNames()  # initialize qNamesList
+        self.__getContinuousNames()  # initialize cNamesList
+        self.__getParameterNames()  # initialize pNamesList
+        self.__getInputNames()  # initialize iNamesList
+        self.__setInputSize()  # defing input value list size
+        self.__getOutputNames()  # initialize oNamesList
+        self.__getContinuousValues()  # initialize cValuesList
+        self.__getParameterValues()  # initialize pValuesList
+        self.__getInputValues()  # initialize input value list
+        self.__getOutputValues()  # initialize oValuesList
+        self.__getSimulationValues()  # initialize simulation value list
 
-
-    #request to OMC
-    def requestApi(self, apiName, entity=None, properties=None ):#2
+    # request to OMC
+    def requestApi(self, apiName, entity=None, properties=None):  # 2
         if (entity is not None and properties is not None):
             exp = '{}({}, {})'.format(apiName, entity, properties)
         elif entity is not None and properties is None:
@@ -744,11 +748,11 @@ class ModelicaSystem(object):
         try:
             res = self.getconn.sendExpression(exp)
         except Exception as e:
-            print (e)
+            print(e)
             res = None
         return res
 
-    #create detail quantities list
+    # create detail quantities list
     def __createQuantitiesList(self):
         rootCQ = self.root
         if not self.quantitiesList:
@@ -764,18 +768,18 @@ class ModelicaSystem(object):
                 start = None
                 for att in ch:
                     start = att.get('start')
-                self.quantitiesList.append(Quantity(name, start, changable, variability, description, causality,alias,aliasvariable))
+                self.quantitiesList.append(Quantity(name, start, changable, variability, description, causality, alias, aliasvariable))
         return self.quantitiesList
 
-    #to get list of all quantities names
+    # to get list of all quantities names
     def __getQuantitiesNames(self):
         if not self.qNamesList:
             for q in self.quantitiesList:
                 self.qNamesList.append(q.name)
         return self.qNamesList
 
-    #check if names exist
-    def __checkAvailability(self, names, chkList, inputFlag = None):
+    # check if names exist
+    def __checkAvailability(self, names, chkList, inputFlag=None):
         try:
             if isinstance(names, list):
                 nonExistingList = []
@@ -783,22 +787,22 @@ class ModelicaSystem(object):
                     if n not in chkList:
                         nonExistingList.append(n)
                 if nonExistingList:
-                    print ('Error!!! ' + str(nonExistingList)  + ' does not exist.')
+                    print('Error!!! ' + str(nonExistingList) + ' does not exist.')
                     return False
             elif isinstance(names, str):
                 if names not in chkList:
-                    print ('Error!!! ' + names  + ' does not exist.')
+                    print('Error!!! ' + names + ' does not exist.')
                     return False
             else:
-                print ('Error!!! Incorrect format')
+                print('Error!!! Incorrect format')
                 return False
             return True
 
         except Exception as e:
-            print (e)
+            print(e)
 
-    #to get details of quantities names
-    def getQuantities(self, names = None):#3
+    # to get details of quantities names
+    def getQuantities(self, names=None):  # 3
         """
         This method returns list of dictionaries. It displays details of quantities such as name, value, changeable, and description, where changeable means  if value for corresponding quantity name is changeable or not. It can be called :
             •without argument: it returns list of dictionaries of all quantities
@@ -815,7 +819,7 @@ class ModelicaSystem(object):
                     qlistnames = []
                     for q in self.quantitiesList:
                         if names == q.name:
-                            qlistnames.append({'Name':q.name, 'Value':q.start,'Changeable' : q.changable, 'Variability': q.variability, 'alias':q.alias,'aliasvariable':q.aliasvariable, 'Description':q.description})
+                            qlistnames.append({'Name': q.name, 'Value': q.start, 'Changeable': q.changable, 'Variability': q.variability, 'alias': q.alias, 'aliasvariable': q.aliasvariable, 'Description': q.description})
                             break
                     return qlistnames
                 elif isinstance(names, list):
@@ -823,20 +827,20 @@ class ModelicaSystem(object):
                     for n in names:
                         for q in self.quantitiesList:
                             if n == q.name:
-                                qlist.append({'Name':q.name, 'Value':q.start,'Changeable' : q.changable, 'Variability': q.variability,'alias':q.alias,'aliasvariable':q.aliasvariable, 'Description':q.description})
+                                qlist.append({'Name': q.name, 'Value': q.start, 'Changeable': q.changable, 'Variability': q.variability, 'alias': q.alias, 'aliasvariable': q.aliasvariable, 'Description': q.description})
                                 break
                     return qlist
                 else:
-                    print ('Error!!! Incorrect format')
+                    print('Error!!! Incorrect format')
             else:
                 qlist = []
                 for q in self.quantitiesList:
-                    qlist.append({'Name':q.name, 'Value':q.start,'Changeable' : q.changable, 'Variability': q.variability, 'alias':q.alias,'aliasvariable':q.aliasvariable,'Description':q.description})
+                    qlist.append({'Name': q.name, 'Value': q.start, 'Changeable': q.changable, 'Variability': q.variability, 'alias': q.alias, 'aliasvariable': q.aliasvariable, 'Description': q.description})
                 return qlist
         except Exception as e:
-            print (e)
+            print(e)
 
-    #to get list of quantities name that are continuous variability
+    # to get list of quantities name that are continuous variability
     def __getContinuousNames(self):
         """
         This method returns list of quantities name that are continuous. It can be called:
@@ -855,14 +859,14 @@ class ModelicaSystem(object):
                 if n not in chkList:
                     nonExistingList.append(n)
             if nonExistingList:
-                print ('Error!!!' + str(nonExistingList) + ' does not exist.')
+                print('Error!!!' + str(nonExistingList) + ' does not exist.')
                 return False
             return True
         else:
-            print ('Error!!! Incorrect format')
+            print('Error!!! Incorrect format')
             return False
 
-    def getContinuous(self, *names):#4
+    def getContinuous(self, *names):  # 4
         """
         This method returns dict. The key is continuous names and value is corresponding continuous value.
         If *name is None then the function will return dict which contain all continuous names as key and value as corresponding values. eg., getContinuous()
@@ -896,11 +900,11 @@ class ModelicaSystem(object):
 
         except Exception:
             if pyparsing.ParseException:
-                print ('Error!!! Name does not exist or incorrect format ')
+                print('Error!!! Name does not exist or incorrect format ')
             else:
                 raise
 
-    def getParameters(self, *names):#5
+    def getParameters(self, *names):  # 5
         """
         This method returns dict. The key is parameter names and value is corresponding parameter value.
         If *name is None then the function will return dict which contain all parameter names as key and value as corresponding values. eg., getParameters()
@@ -908,7 +912,7 @@ class ModelicaSystem(object):
         """
         return self.__getXXXs(names, self.__getParameterNames(), self.__getParameterValues())
 
-    def getInputs(self, *names):#6
+    def getInputs(self, *names):  # 6
         """
         This method returns dict. The key is input names and value is corresponding input value.
         If *name is None then the function will return dict which contain all input names as key and value as corresponding values. eg., getInputs()
@@ -916,7 +920,7 @@ class ModelicaSystem(object):
         """
         return self.__getXXXs(names, self.__getInputNames(), self.__getInputValues())
 
-    def getOutputs(self, *names):#7
+    def getOutputs(self, *names):  # 7
         """
         This method returns dict. The key is output names and value is corresponding output value.
         If *name is None then the function will return dict which contain all output names as key and value as corresponding values. eg., getOutputs()
@@ -954,7 +958,7 @@ class ModelicaSystem(object):
 
         except Exception:
             if pyparsing.ParseException:
-                print ('Error!!! Name does not exist or incorrect format ')
+                print('Error!!! Name does not exist or incorrect format ')
             else:
                 raise
 
@@ -970,7 +974,7 @@ class ModelicaSystem(object):
                     self.pNamesList.append(l.name)
         return self.pNamesList
 
-    #to get list of quantities name that are input
+    # to get list of quantities name that are input
     def __getInputNames(self):
         """
         This method returns list of quantities name that are inputs. It can be called:
@@ -983,13 +987,13 @@ class ModelicaSystem(object):
                     self.iNamesList.append(l.name)
         return self.iNamesList
 
-    #set input value list size
+    # set input value list size
     def __setInputSize(self):
         size = len(self.__getInputNames())
-        self.inputsVal = [None]*size
+        self.inputsVal = [None] * size
 
-    #to get list of quantities name that are output
-    #Todo: has not been tested yet due to lack of the model that contains output.
+    # to get list of quantities name that are output
+    # Todo: has not been tested yet due to lack of the model that contains output.
 
     def __getOutputNames(self):
         """
@@ -1004,7 +1008,7 @@ class ModelicaSystem(object):
                     self.oNamesList.append(l.name)
         return self.oNamesList
 
-    #to get values of continuous quantities name
+    # to get values of continuous quantities name
     def __getContinuousValues(self, contiName=None):
         """
         This method returns list of values of the quantities name that are continuous. It can be called:
@@ -1027,12 +1031,12 @@ class ModelicaSystem(object):
             return self.cValuesList
         else:
             try:
-                #if isinstance(contiName, list):
+                # if isinstance(contiName, list):
                 checking = self.__checkAvailability(contiName, self.__getContinuousNames())
-                #if checking is False:
+                # if checking is False:
                 if not checking:
                     return
-                if isinstance (contiName, str):
+                if isinstance(contiName, str):
                     index_ = self.cNamesList.index(contiName)
                     return (self.cValuesList[index_])
                 valList = []
@@ -1041,10 +1045,10 @@ class ModelicaSystem(object):
                     valList.append(self.cValuesList[index_])
                 return valList
             except Exception as e:
-                print (e)
+                print(e)
 
-    #to get values of parameter quantities name
-    def __getParameterValues(self, paraName = None):
+    # to get values of parameter quantities name
+    def __getParameterValues(self, paraName=None):
         """
         This method returns list of values of the quantities name that are parameters. It can be called:
             •without any arguments: return list of values of all quantities (parameter) name
@@ -1082,9 +1086,9 @@ class ModelicaSystem(object):
                     valList.append(self.pValuesList[index_])
                 return valList
             except Exception as e:
-                print (e)
+                print(e)
 
-    #to get values of input names
+    # to get values of input names
     def __getInputValues(self, iName=None):
         """
         This method returns list of values of the quantities name that are inputs. It can be called:
@@ -1096,18 +1100,18 @@ class ModelicaSystem(object):
             if iName is None:
                 return self.inputsVal
             elif isinstance(iName, str):
-                checking = self.__checkAvailability(iName,self.__getInputNames())
+                checking = self.__checkAvailability(iName, self.__getInputNames())
                 if not checking:
                     return
                 index_ = self.iNamesList.index(iName)
                 return self.inputsVal[index_]
             else:
-                print ('Error!!! Incorrect format')
+                print('Error!!! Incorrect format')
         except Exception as e:
-            print (e)
+            print(e)
 
-    #to get values of output quantities name
-    #Todo: has not been tested yet due to lack of the model that contains output.
+    # to get values of output quantities name
+    # Todo: has not been tested yet due to lack of the model that contains output.
     def __getOutputValues(self):
         """
         This method returns list of values of the quantities name that are outputs. It can be called:
@@ -1121,7 +1125,7 @@ class ModelicaSystem(object):
                     self.oValuesList.append(l.start)
         return self.oValuesList
 
-    #to get simulation options values
+    # to get simulation options values
     def __getSimulationValues(self):
         if not self.simValuesList:
             root = self.tree.getroot()
@@ -1139,7 +1143,7 @@ class ModelicaSystem(object):
                 self.simValuesList.append(solver)
         return self.simValuesList
 
-    def getSimulationOptions(self, *names):#8
+    def getSimulationOptions(self, *names):  # 8
         """
         This method returns dict. The key is simulation option names and value is corresponding simulation option value.
         If *name is None then the function will return dict which contain all simulation option names as key and value as corresponding values. eg., getSimulationOptions()
@@ -1147,7 +1151,7 @@ class ModelicaSystem(object):
         """
         return self.__getXXXs(names, self.simNamesList, self.simValuesList)
 
-    def getLinearizationOptions(self, *names):#9
+    def getLinearizationOptions(self, *names):  # 9
         """
         This method returns dict. The key is linearize option names and value is corresponding linearize option value.
         If *name is None then the function will return dict which contain all linearize option names as key and value as corresponding values. eg., getLinearizationOptions()
@@ -1156,7 +1160,7 @@ class ModelicaSystem(object):
         return self.__getXXXs(names, self.linearizeOptionsNamesList, self.linearizeOptionsValuesList)
 
     def __getXXXs(self, names, namesList, valList):
-        #todo: check_Tuple is not working for tuple format
+        # todo: check_Tuple is not working for tuple format
         if not self.linearizationFlag:
             checking = self.__checkTuple(names, namesList)
             if not checking:
@@ -1181,7 +1185,7 @@ class ModelicaSystem(object):
                 return tupVal
             elif len(names) == 1:
                 n, = names
-                if (hasattr(n,'__iter__')):
+                if (hasattr(n, '__iter__')):
                     val = []
                     for i in n:
                         index_ = namesList.index(i)
@@ -1192,25 +1196,25 @@ class ModelicaSystem(object):
                     index_ = namesList.index(n)
                     return valList[index_]
         except ValueError as e:
-            print (e)
+            print(e)
 
-    def getOptimizationOptions(self, *names):#10
+    def getOptimizationOptions(self, *names):  # 10
         return self.__getXXXs(names, self.optimizeOptionsNamesList, self.optimizeOptionsValuesList)
 
-    #to simulate or re-simulate model
-    def simulate(self):#11
+    # to simulate or re-simulate model
+    def simulate(self):  # 11
         """
         This method simulates model according to the simulation options. It can be called:
             •only without any arguments: simulate the model
         """
-        #if (self.inputFlag == True):
-        if (self.inputFlag):#if model has input quantities
+        # if (self.inputFlag == True):
+        if (self.inputFlag):  # if model has input quantities
             inpVal = self.__getInputValues()
             ind = 0
             for i in inpVal:
                 if self.simValuesList[0] != i[0][0] or self.simValuesList[1] != i[-1][0]:
                     inpName = self.iNamesList[ind]
-                    print ('!!! startTime / stopTime not defined for Input ' + inpName)
+                    print('!!! startTime / stopTime not defined for Input ' + inpName)
                     return
                 ind += 1
             nameVal = self.getInputs()
@@ -1218,82 +1222,82 @@ class ModelicaSystem(object):
                 tupleList = nameVal.get(n)
                 for l in tupleList:
                     if l[0] < float(self.simValuesList[0]):
-                        print ('Input time value is less than simulation startTime')
+                        print('Input time value is less than simulation startTime')
                         return
-            self.__simInput()#create csv file
+            self.__simInput()  # create csv file
 
-            if (platform.system()=="Windows"):
-               getExeFile=os.path.join(os.getcwd(),'{}.{}'.format(self.modelName, "exe")).replace("\\","/")
+            if (platform.system() == "Windows"):
+                getExeFile = os.path.join(os.getcwd(), '{}.{}'.format(self.modelName, "exe")).replace("\\", "/")
             else:
-               getExeFile=os.path.join(os.getcwd(),self.modelName).replace("\\","/")
+                getExeFile = os.path.join(os.getcwd(), self.modelName).replace("\\", "/")
 
             #getExeFile = '{}.{}'.format(self.modelName)
 
             check_exeFile_ = os.path.exists(getExeFile)
             if(check_exeFile_):
                 cmd = getExeFile + " -csvInput=" + self.csvFile
-                if(platform.system()=="Windows"):
-                   omhome=os.path.join(os.environ.get("OPENMODELICAHOME"),'bin').replace("\\","/")
-                   my_env = os.environ.copy()
-                   my_env["PATH"] = omhome + os.pathsep + my_env["PATH"]
-                   p=subprocess.Popen(cmd, env=my_env)
-                   p.wait()
-                   p.terminate()
+                if(platform.system() == "Windows"):
+                    omhome = os.path.join(os.environ.get("OPENMODELICAHOME"), 'bin').replace("\\", "/")
+                    my_env = os.environ.copy()
+                    my_env["PATH"] = omhome + os.pathsep + my_env["PATH"]
+                    p = subprocess.Popen(cmd, env=my_env)
+                    p.wait()
+                    p.terminate()
                 else:
-                   os.system(cmd)
+                    os.system(cmd)
                 #subprocess.call(cmd, shell = False)
                 self.simulationFlag = True
-                resultfilename=self.modelName+'_res.mat'
+                resultfilename = self.modelName + '_res.mat'
                 return
             else:
-                print ("Error: application file not generated yet")
+                print("Error: application file not generated yet")
                 return
         else:
-            if (platform.system()=="Windows"):
-               getExeFile=os.path.join(os.getcwd(),'{}.{}'.format(self.modelName, "exe")).replace("\\","/")
+            if (platform.system() == "Windows"):
+                getExeFile = os.path.join(os.getcwd(), '{}.{}'.format(self.modelName, "exe")).replace("\\", "/")
             else:
-               getExeFile=os.path.join(os.getcwd(),self.modelName).replace("\\","/")
-               #getExeFile = '{}.{}'.format(self.modelName, "exe")
+                getExeFile = os.path.join(os.getcwd(), self.modelName).replace("\\", "/")
+                #getExeFile = '{}.{}'.format(self.modelName, "exe")
 
             check_exeFile_ = os.path.exists(getExeFile)
 
             if(check_exeFile_):
                 cmd = getExeFile
-                if(platform.system()=="Windows"):
-                   omhome=os.path.join(os.environ.get("OPENMODELICAHOME"),'bin').replace("\\","/")
-                   my_env = os.environ.copy()
-                   my_env["PATH"] = omhome + os.pathsep + my_env["PATH"]
-                   p=subprocess.Popen(cmd, env=my_env)
-                   p.wait()
-                   p.terminate()
+                if(platform.system() == "Windows"):
+                    omhome = os.path.join(os.environ.get("OPENMODELICAHOME"), 'bin').replace("\\", "/")
+                    my_env = os.environ.copy()
+                    my_env["PATH"] = omhome + os.pathsep + my_env["PATH"]
+                    p = subprocess.Popen(cmd, env=my_env)
+                    p.wait()
+                    p.terminate()
                 else:
-                   os.system(cmd)
+                    os.system(cmd)
                 self.simulationFlag = True
                 #self.outputFlag = True
-                resultfilename=self.modelName+'_res.mat'
+                resultfilename = self.modelName + '_res.mat'
                 return
             else:
-                print ("Error: application file not generated yet")
+                print("Error: application file not generated yet")
 
-    #to extract simulation results
-    def getSolutions(self, *varList):#12
+    # to extract simulation results
+    def getSolutions(self, *varList):  # 12
         """
         This method returns tuple of numpy arrays. It can be called:
             •with a list of quantities name in string format as argument: it returns the simulation results of the corresponding names in the same order. Here it supports Python unpacking depending upon the number of variables assigned.
         """
-        ## check for result file exits
+        # check for result file exits
         res_mat = '_res.mat'
         resFile = "".join([self.modelName, res_mat])
         if (not os.path.exists(resFile)):
-            print ("Error: Result file does not exist")
+            print("Error: Result file does not exist")
             exit()
         else:
             if len(varList) == 0:
                 #validSolution = ['time'] + self.__getInputNames() + self.__getContinuousNames() + self.__getParameterNames()
-                validSolution = self.getconn.sendExpression("readSimulationResultVars(\"" +resFile+ "\")")
+                validSolution = self.getconn.sendExpression("readSimulationResultVars(\"" + resFile + "\")")
                 return validSolution
 
-            #if isinstance(varList, tuple) and all(len(a)==1 for a in varList):
+            # if isinstance(varList, tuple) and all(len(a)==1 for a in varList):
             elif isinstance(varList, tuple) and all(isinstance(a, str) for a in varList):
                 for v in varList:
                     if v == 'time':
@@ -1308,7 +1312,7 @@ class ModelicaSystem(object):
                 exp2 = "closeSimulationResultFile()"
                 self.getconn.sendExpression(exp2)
                 if len(npRes) == 1:
-                    tup=(npRes.ravel())
+                    tup = (npRes.ravel())
                     return tup
                 else:
                     tup = tuple(npRes)
@@ -1324,8 +1328,8 @@ class ModelicaSystem(object):
                 self.getconn.sendExpression(exp2)
                 return npRes
 
-    #to set continuous quantities values
-    def setContinuous(self, **cvals):#13
+    # to set continuous quantities values
+    def setContinuous(self, **cvals):  # 13
         """
         This method is used to set continuous values. It can be called:
             •with a sequence of continuous name and assigning corresponding values as arguments as show in the example below:
@@ -1333,8 +1337,8 @@ class ModelicaSystem(object):
         """
         self.__setValue(cvals, self.__getContinuousNames(), self.cValuesList, 'continuous', 0)
 
-    #to set parameter quantities values
-    def setParameters(self, **pvals):#14
+    # to set parameter quantities values
+    def setParameters(self, **pvals):  # 14
         """
         This method is used to set parameter values. It can be called:
             •with a sequence of parameter name and assigning corresponding value as arguments as show in the example below:
@@ -1342,8 +1346,8 @@ class ModelicaSystem(object):
         """
         self.__setValue(pvals, self.__getParameterNames(), self.__getParameterValues(), 'parameter', 0)
 
-    #to set input quantities value
-    def setInputs(self, **nameVal):#15
+    # to set input quantities value
+    def setInputs(self, **nameVal):  # 15
         """
         This method is used to set input values. It can be called:
             •with a sequence of input name and assigning corresponding values as arguments as show in the example below:
@@ -1354,24 +1358,24 @@ class ModelicaSystem(object):
             for n in nameVal:
                 tupleList = nameVal.get(n)
                 if isinstance(tupleList, list):
-                    if tupleList != sorted(tupleList, key=lambda x:x[0]):
-                        print ('Time value should be in increasing order')
+                    if tupleList != sorted(tupleList, key=lambda x: x[0]):
+                        print('Time value should be in increasing order')
                         return
                     for l in tupleList:
                         if isinstance(l, tuple):
                             if l[0] < float(self.simValuesList[0]):
-                                print ('Input time value is less than simulation startTime')
+                                print('Input time value is less than simulation startTime')
                                 return
-                            if len(l)!=2:
-                                print ('Value for ' + n + ' is in incorrect format!')
+                            if len(l) != 2:
+                                print('Value for ' + n + ' is in incorrect format!')
                                 return
                         else:
-                            print ('Error!!! Value must be in tuple format')
+                            print('Error!!! Value must be in tuple format')
                             return
                 elif isinstance(tupleList, int) or isinstance(tupleList, float):
                     continue
                 else:
-                    print ('Error!!! Input values should be tuple list for ' + n)
+                    print('Error!!! Input values should be tuple list for ' + n)
                     return
             lst2 = []
             lstInd = []
@@ -1380,7 +1384,7 @@ class ModelicaSystem(object):
                     index = self.iNamesList.index(n)
                     if isinstance(nameVal.get(n), int) or isinstance(nameVal.get(n), float):
                         self.specialNames.append((n, nameVal.get(n), True))
-                        self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n)) ]
+                        self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n))]
                     else:
                         self.inputsVal[index] = nameVal.get(n)
                 else:
@@ -1388,8 +1392,8 @@ class ModelicaSystem(object):
                         s_, = tuple([item for item in self.specialNames if n in item])
 
                         index = self.iNamesList.index(n)
-                        if isinstance(nameVal.get(n),int) or isinstance(nameVal.get(n), float):
-                            self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n)) ]
+                        if isinstance(nameVal.get(n), int) or isinstance(nameVal.get(n), float):
+                            self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n))]
                         else:
                             ind = self.specialNames.index(s_)
                             self.specialNames.pop(ind)
@@ -1400,25 +1404,25 @@ class ModelicaSystem(object):
                         index = self.iNamesList.index(n)
                         if isinstance(nameVal.get(n), int) or isinstance(nameVal.get(n), float):
                             self.specialNames.append((n, nameVal.get(n), True))
-                            self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n)) ]
+                            self.inputsVal[index] = [(float(self.simValuesList[0]), nameVal.get(n)), (float(self.simValuesList[1]), nameVal.get(n))]
                         else:
                             self.inputsVal[index] = nameVal.get(n)
                 self.inputFlag = True
 
         except Exception:
-            print ( "Error:!!! " + n + " is not an input")
+            print("Error:!!! " + n + " is not an input")
             return
 
-    #To create csv file for inputs
+    # To create csv file for inputs
     def __simInput(self):
-        sl=list() #Actual timestamps
+        sl = list()  # Actual timestamps
         skip = False
         inp = list()
         inp = deepcopy(self.__getInputValues())
         for i in inp:
-            cl=list()
-            el=list()
-            for (t,x) in i:
+            cl = list()
+            el = list()
+            for (t, x) in i:
                 cl.append(t)
             for i in cl:
                 if skip == True:
@@ -1443,29 +1447,29 @@ class ModelicaSystem(object):
         inpSortedList = list()
         sortedList = list()
         for i in inp:
-            sortedList = sorted(i, key = lambda x:x[0])
+            sortedList = sorted(i, key=lambda x: x[0])
             inpSortedList.append(sortedList)
         for i in inpSortedList:
             ind = 0
-            for (t, x ) in i:
+            for (t, x) in i:
                 if x == '?':
-                    t1=i[ind-1][0]
-                    u1 = i[ind-1][1]
-                    t2=i[ind+1][0]
-                    u2 = i[ind+1][1]
+                    t1 = i[ind - 1][0]
+                    u1 = i[ind - 1][1]
+                    t2 = i[ind + 1][0]
+                    u2 = i[ind + 1][1]
                     nex = 2
                     while (u2 == '?'):
                         u2 = i[ind + nex][1]
-                        t2 = i[ind + nex ][0]
+                        t2 = i[ind + nex][0]
                         nex += 1
-                    x = float(u1 + (u2-u1)*(t-t1)/(t2-t1))
-                    i[ind] = (t,x)
-                ind+=1
+                    x = float(u1 + (u2 - u1) * (t - t1) / (t2 - t1))
+                    i[ind] = (t, x)
+                ind += 1
         slSet = list()
         slSet = set(sl)
         for i in inpSortedList:
             tempTime = list()
-            for (t,x) in i:
+            for (t, x) in i:
                 tempTime.append(t)
             inSl = None
             inI = None
@@ -1474,39 +1478,39 @@ class ModelicaSystem(object):
                 inI = tempTime.count(s)
                 if inSl != inI:
                     test = list()
-                    test = [(x,y) for x, y in i if x  == s]
+                    test = [(x, y) for x, y in i if x == s]
                     i.append(test[0])
         newInpList = list()
         tempSorting = list()
         for i in inpSortedList:
-            #i.sort() => just sorting might not work so need to sort according to 1st element of a tuple
-            tempSorting = sorted(i, key = lambda x:x[0])
+            # i.sort() => just sorting might not work so need to sort according to 1st element of a tuple
+            tempSorting = sorted(i, key=lambda x: x[0])
             newInpList.append(tempSorting)
 
         interpolated_inputs_all = list()
         for i in newInpList:
             templist = list()
-            for (t,x) in i:
+            for (t, x) in i:
                 templist.append(x)
             interpolated_inputs_all.append(templist)
 
-        name_ ='time'
+        name_ = 'time'
         name = ','.join(self.__getInputNames())
-        name = '{},{},{}'.format(name_,name,'end')
+        name = '{},{},{}'.format(name_, name, 'end')
 
-        a=''
-        l=[]
+        a = ''
+        l = []
         l.append(name)
-        for i in range(0,len(sl)):
-            a =("%s,%s" % (str(float(sl[i])),",".join(list(str(float(inppp[i]))  for inppp in interpolated_inputs_all))))+',0'
+        for i in range(0, len(sl)):
+            a = ("%s,%s" % (str(float(sl[i])), ",".join(list(str(float(inppp[i])) for inppp in interpolated_inputs_all)))) + ',0'
             l.append(a)
 
         self.csvFile = '{}.csv'.format(self.modelName)
-        with open (self.csvFile, "w") as f:
-            writer=csv.writer(f, delimiter='\n')
+        with open(self.csvFile, "w") as f:
+            writer = csv.writer(f, delimiter='\n')
             writer.writerow(l)
 
-    #to set values for continuous and parameter quantities
+    # to set values for continuous and parameter quantities
     def __setValue(self, nameVal, namesList, valuesList, quantity, index):
         try:
             for n in nameVal:
@@ -1514,7 +1518,7 @@ class ModelicaSystem(object):
                     for l in self.quantitiesList:
                         if(l.name == n):
                             if l.changable == 'false':
-                                print ("!!! value cannot be set for " + n)
+                                print("!!! value cannot be set for " + n)
                             else:
                                 l.start = float(nameVal.get(n))
                                 index_ = namesList.index(n)
@@ -1523,29 +1527,29 @@ class ModelicaSystem(object):
                                 rootSet = self.root
                                 for paramVar in rootSet.iter('ScalarVariable'):
                                     if paramVar.get('name') == str(n):
-                                        c=paramVar.getchildren()
+                                        c = paramVar.getchildren()
                                         for attr in c:
                                             val = float(nameVal.get(n))
                                             attr.set('start', str(val))
                                             self.tree.write(self.xmlFile,  encoding='UTF-8', xml_declaration=True)
                                 index = index + 1
                 else:
-                    print ('Error: ' + n + ' is not ' + quantity)
+                    print('Error: ' + n + ' is not ' + quantity)
 
         except Exception as e:
-            print (e)
+            print(e)
 
-    #to set simulation options values
-    def setSimulationOptions(self, **simOptions):#16
+    # to set simulation options values
+    def setSimulationOptions(self, **simOptions):  # 16
         """
         This method is used to set simulation options. It can be called:
             •with a sequence of simulation options name and assigning corresponding values as arguments as show in the example below:
             setSimulationOptions(stopTime = 100, solver = 'euler')
         """
-        return self.__setOptions(simOptions, self.simNamesList, self.simValuesList,0)
+        return self.__setOptions(simOptions, self.simNamesList, self.simValuesList, 0)
 
-    #to set optimization options values
-    def setOptimizationOptions(self, **optimizationOptions):#17
+    # to set optimization options values
+    def setOptimizationOptions(self, **optimizationOptions):  # 17
         """
         This method is used to set optimization options. It can be called:
             •with a sequence of optimization options name and assigning corresponding values as arguments as show in the example below:
@@ -1553,8 +1557,8 @@ class ModelicaSystem(object):
         """
         return self.__setOptions(optimizationOptions, self.optimizeOptionsNamesList, self.optimizeOptionsValuesList)
 
-    #to set linearization options values
-    def setLinearizationOptions(self, **linearizationOptions):#18
+    # to set linearization options values
+    def setLinearizationOptions(self, **linearizationOptions):  # 18
         """
         This method is used to set linearization options. It can be called:
             •with a sequence of linearization options name and assigning corresponding value as arguments as show in the example below
@@ -1562,23 +1566,23 @@ class ModelicaSystem(object):
         """
         return self.__setOptions(linearizationOptions, self.linearizeOptionsNamesList, self.linearizeOptionsValuesList)
 
-    #to set options for simulation, optimization and linearization
-    def __setOptions(self, options, namesList, valuesList, index = None):
+    # to set options for simulation, optimization and linearization
+    def __setOptions(self, options, namesList, valuesList, index=None):
         try:
             for opt in options:
                 if opt in namesList:
                     if opt == 'stopTime':
-                        if float(options.get(opt))<=float(valuesList[0]):
-                            print ('!!! stoptTime should be greater than startTime')
+                        if float(options.get(opt)) <= float(valuesList[0]):
+                            print('!!! stoptTime should be greater than startTime')
                             return
                     if opt == 'startTime':
-                        if float(options.get(opt))>=float(valuesList[1]):
-                            print ('!!! startTime should be less than stopTime')
+                        if float(options.get(opt)) >= float(valuesList[1]):
+                            print('!!! startTime should be less than stopTime')
                             return
                     index_ = namesList.index(opt)
                     valuesList[index_] = options.get(opt)
                 else:
-                    print ('!!!' + opt + ' is not an option')
+                    print('!!!' + opt + ' is not an option')
                     continue
                 if index is not None:
                     rootSSC = self.root
@@ -1593,10 +1597,10 @@ class ModelicaSystem(object):
                         self.inputsVal[index] = [(float(self.simValuesList[0]), n[1]), (float(self.simValuesList[1]), n[1])]
 
         except Exception as e:
-            print (e)
+            print(e)
 
-    #to convert Modelica model to FMU
-    def convertMo2Fmu(self):#19
+    # to convert Modelica model to FMU
+    def convertMo2Fmu(self):  # 19
         """
         This method is used to generate FMU from the given Modelica model. It creates "modelName.fmu" in the current working directory. It can be called:
             •only without any arguments
@@ -1605,12 +1609,12 @@ class ModelicaSystem(object):
         convertMo2FmuError = ''
         translateModelFMUResult = self.requestApi('translateModelFMU', self.modelName)
         if convertMo2FmuError:
-            print (convertMo2FmuError)
+            print(convertMo2FmuError)
 
         return translateModelFMUResult
 
-    #to convert FMU to Modelica model
-    def convertFmu2Mo(self, fmuName):#20
+    # to convert FMU to Modelica model
+    def convertFmu2Mo(self, fmuName):  # 20
         """
         In order to load FMU, at first it needs to be translated into Modelica model. This method is used to generate Modelica model from the given FMU. It generates "fmuName_me_FMU.mo". It can be called:
             •only without any arguments
@@ -1624,31 +1628,31 @@ class ModelicaSystem(object):
         importResult = self.requestApi('importFMU', fmuName)
         convertFmu2MoError = self.requestApi('getErrorString')
         if convertFmu2MoError:
-            print (convertFmu2MoError)
+            print(convertFmu2MoError)
 
         return importResult
 
-    #to optimize model
-    def optimize(self):#21
+    # to optimize model
+    def optimize(self):  # 21
         """
         This method optimizes model according to the optimized options. It can be called:
             •only without any arguments
         """
 
         cName = self.modelName
-        properties = '{}={}, {}={}, {}={}, {}={}, {}={}'.format(self.optimizeOptionsNamesList[0],self.optimizeOptionsValuesList[0],self.optimizeOptionsNamesList[1],self.optimizeOptionsValuesList[1],self.optimizeOptionsNamesList[2],self.optimizeOptionsValuesList[2],self.optimizeOptionsNamesList[3],self.optimizeOptionsValuesList[3],self.optimizeOptionsNamesList[4],self.optimizeOptionsValuesList[4])
+        properties = '{}={}, {}={}, {}={}, {}={}, {}={}'.format(self.optimizeOptionsNamesList[0], self.optimizeOptionsValuesList[0], self.optimizeOptionsNamesList[1], self.optimizeOptionsValuesList[1], self.optimizeOptionsNamesList[2], self.optimizeOptionsValuesList[2], self.optimizeOptionsNamesList[3], self.optimizeOptionsValuesList[3], self.optimizeOptionsNamesList[4], self.optimizeOptionsValuesList[4])
 
         optimizeError = ''
         self.getconn.sendExpression("setCommandLineOptions(\"-g=Optimica\")")
         optimizeResult = self.requestApi('optimize', cName, properties)
         optimizeError = self.requestApi('getErrorString')
         if optimizeError:
-            print (optimizeError)
+            print(optimizeError)
 
         return optimizeResult
 
-    #to linearize model
-    def linearize(self):#22
+    # to linearize model
+    def linearize(self):  # 22
         """
         This method linearizes model according to the linearized options. This will generate a linear model that consists of matrices A, B, C and D.  It can be called:
             •only without any arguments
@@ -1658,34 +1662,34 @@ class ModelicaSystem(object):
             cName = self.modelName
             #self.requestApi("setCommandLineOptions", "+generateSymbolicLinearization")
             self.getconn.sendExpression("setCommandLineOptions(\"+generateSymbolicLinearization\")")
-            properties = "{}={}, {}={}, {}={}, {}={}, {}={}".format(self.linearizeOptionsNamesList[0],self.linearizeOptionsValuesList[0],self.linearizeOptionsNamesList[1],self.linearizeOptionsValuesList[1],self.linearizeOptionsNamesList[2],self.linearizeOptionsValuesList[2],self.linearizeOptionsNamesList[3],self.linearizeOptionsValuesList[3],self.linearizeOptionsNamesList[4],self.linearizeOptionsValuesList[4])
-            x=self.getParameters()
-            getparamvalues=','.join("%s=%r" % (key,val) for (key,val) in x.iteritems())
-            override="-override="+getparamvalues
+            properties = "{}={}, {}={}, {}={}, {}={}, {}={}".format(self.linearizeOptionsNamesList[0], self.linearizeOptionsValuesList[0], self.linearizeOptionsNamesList[1], self.linearizeOptionsValuesList[1], self.linearizeOptionsNamesList[2], self.linearizeOptionsValuesList[2], self.linearizeOptionsNamesList[3], self.linearizeOptionsValuesList[3], self.linearizeOptionsNamesList[4], self.linearizeOptionsValuesList[4])
+            x = self.getParameters()
+            getparamvalues = ','.join("%s=%r" % (key, val) for (key, val) in x.iteritems())
+            override = "-override=" + getparamvalues
             if self.inputFlag:
                 nameVal = self.getInputs()
                 for n in nameVal:
                     tupleList = nameVal.get(n)
                     for l in tupleList:
                         if l[0] < float(self.simValuesList[0]):
-                            print ('Input time value is less than simulation startTime')
+                            print('Input time value is less than simulation startTime')
                             return
                 self.__simInput()
-                flags="-csvInput="+self.csvFile+" "+override
-                self.getconn.sendExpression("linearize(" + self.modelName + ","+ properties +", simflags=\" "+ flags +" \")")
+                flags = "-csvInput=" + self.csvFile + " " + override
+                self.getconn.sendExpression("linearize(" + self.modelName + "," + properties + ", simflags=\" " + flags + " \")")
                 linearizeError = ''
                 linearizeError = self.requestApi('getErrorString')
                 if linearizeError:
-                    print (linearizeError)
+                    print(linearizeError)
             else:
                 linearizeError = ''
-                self.getconn.sendExpression("linearize(" + self.modelName + ","+ properties +", simflags=\" "+ override +" \")")
+                self.getconn.sendExpression("linearize(" + self.modelName + "," + properties + ", simflags=\" " + override + " \")")
                 #linearizeResult = self.requestApi('linearize', cName, properties, simflags)
                 linearizeError = self.requestApi('getErrorString')
                 if linearizeError:
-                    print (linearizeError)
+                    print(linearizeError)
 
-            ## code to get the matrix and linear inputs, outputs and states
+            # code to get the matrix and linear inputs, outputs and states
             getLinFile = '{}_{}.{}'.format('linear', self.modelName, 'mo')
             checkLinFile = os.path.exists(getLinFile)
             if checkLinFile:
@@ -1695,7 +1699,7 @@ class ModelicaSystem(object):
                 self.requestApi('buildModel', linModelName)
                 lin = ModelicaSystem(getLinFile, linModelName)
                 lin.linearizationFlag = True
-                self.linearquantitiesList=lin.getQuantities()
+                self.linearquantitiesList = lin.getQuantities()
                 self.getLinearQuantityInformation()
                 A = []
                 B = []
@@ -1721,15 +1725,15 @@ class ModelicaSystem(object):
             raise e
 
     def getLinearQuantityInformation(self):
-        ## function which extracts linearised states, inputs and outputs
+        # function which extracts linearised states, inputs and outputs
         for i in xrange(len(self.linearquantitiesList)):
-            if (self.linearquantitiesList[i]['alias']=='alias'):
-                name=self.linearquantitiesList[i]['Name']
-                if(name[1]=='x'):
+            if (self.linearquantitiesList[i]['alias'] == 'alias'):
+                name = self.linearquantitiesList[i]['Name']
+                if(name[1] == 'x'):
                     self.linearstates.append(name[3:-1])
-                if(name[1]=='u'):
+                if(name[1] == 'u'):
                     self.linearinputs.append(name[3:-1])
-                if(name[1]=='y'):
+                if(name[1] == 'y'):
                     self.linearoutputs.append(name[3:-1])
 
     def getLinearInputs(self):
@@ -1749,13 +1753,13 @@ class ModelicaSystem(object):
                 xElemNames.append(k)
         xElemNames.sort()
         xElemNames.sort(key=len)
-        sortedX=xElemNames
+        sortedX = xElemNames
         size_ = int(self.getParameters(sizeParameter))
         matX = []
         matX = [[] for i in range(size_)]
         for i in range(size_):
             for a in sortedX:
-                if float(a.partition('[')[-1].rpartition(',')[0]) == float(i+1):
+                if float(a.partition('[')[-1].rpartition(',')[0]) == float(i + 1):
                     matX[i].append(a)
         a_ = []
         for i in matX:
@@ -1764,7 +1768,7 @@ class ModelicaSystem(object):
         for i in matX:
             tup = tuple(i)
             xValues.append(self.getParameters(tup))
-        xValues=np.array(xValues)
+        xValues = np.array(xValues)
         return xValues
 
     def __getMatrixA(self):

--- a/setup.py
+++ b/setup.py
@@ -9,47 +9,50 @@ import os
 # Python 3.3 offers shutil.which()
 from distutils import spawn
 
+
 def warningOrError(errorOnFailure, msg):
-  if errorOnFailure:
-    raise Exception(msg)
-  else:
-    print(msg)
+    if errorOnFailure:
+        raise Exception(msg)
+    else:
+        print(msg)
+
 
 def generateIDL():
-  errorOnFailure = not os.path.exists(os.path.join(os.path.dirname(__file__), 'OMPythonIDL', '__init__.py'))
-  try:
-    omhome = os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
-  except:
-    omhome = None
-  omhome = omhome or os.environ.get('OPENMODELICAHOME')
+    errorOnFailure = not os.path.exists(os.path.join(os.path.dirname(__file__), 'OMPythonIDL', '__init__.py'))
+    try:
+        omhome = os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
+    except:
+        omhome = None
+    omhome = omhome or os.environ.get('OPENMODELICAHOME')
 
-  if omhome is None:
-    warningOrError(errorOnFailure, "Failed to find OPENMODELICAHOME (searched for environment variable as well as the omc executable)")
-    return
-  idl = os.path.join(omhome,"share","omc","omc_communication.idl")
-  if not os.path.exists(idl):
-    warningOrError(errorOnFailure, "Path not found: %s" % idl)
-    return
+    if omhome is None:
+        warningOrError(errorOnFailure, "Failed to find OPENMODELICAHOME (searched for environment variable as well as the omc executable)")
+        return
+    idl = os.path.join(omhome, "share", "omc", "omc_communication.idl")
+    if not os.path.exists(idl):
+        warningOrError(errorOnFailure, "Path not found: %s" % idl)
+        return
 
-  if 0!=call(["omniidl","-bpython","-Wbglobal=_OMCIDL","-Wbpackage=OMPythonIDL",idl]):
-    warningOrError(errorOnFailure, "omniidl command failed")
-    return
-  print("Generated OMPythonIDL files")
+    if 0 != call(["omniidl", "-bpython", "-Wbglobal=_OMCIDL", "-Wbpackage=OMPythonIDL", idl]):
+        warningOrError(errorOnFailure, "omniidl command failed")
+        return
+    print("Generated OMPythonIDL files")
+
 
 if sys.platform != 'win32':
-  try:
-    # if we don't have omniidl then don't try to generate OMPythonIDL files.
-    import omniidl
-    hasomniidl = True
-    generateIDL()
-  except ImportError:
-    hasomniidl = False
+    try:
+        # if we don't have omniidl then don't try to generate OMPythonIDL files.
+        import omniidl
+        hasomniidl = True
+        generateIDL()
+    except ImportError:
+        hasomniidl = False
 else:
     hasomniidl = True
 
 OMPython_packages = ['OMPython', 'OMPython.OMParser']
 if hasomniidl:
-  OMPython_packages.extend(['OMPythonIDL', 'OMPythonIDL._OMCIDL', 'OMPythonIDL._OMCIDL__POA'])
+    OMPython_packages.extend(['OMPythonIDL', 'OMPythonIDL._OMCIDL', 'OMPythonIDL._OMCIDL__POA'])
 
 setup(name='OMPython',
       version='3.0.0',
@@ -62,9 +65,9 @@ setup(name='OMPython',
       url='http://openmodelica.org/',
       packages=OMPython_packages,
       install_requires=[
-        # 'omniORB', # Required, but not part of pypi
-        'pyparsing',
-        'numpy',
-        'pyzmq'
+          # 'omniORB', # Required, but not part of pypi
+          'pyparsing',
+          'numpy',
+          'pyzmq'
       ]
-)
+      )

--- a/tests/test_OMParser.py
+++ b/tests/test_OMParser.py
@@ -4,6 +4,7 @@ from OMPython import OMParser
 
 typeCheck = OMParser.typeCheck
 
+
 class TypeCheckTester(unittest.TestCase):
     def testNewlineBehaviour(self):
         pass
@@ -34,6 +35,7 @@ class TypeCheckTester(unittest.TestCase):
 
     def testUnStringable(self):
         pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this closes #35
exact command used:
```
autopep8 --in-place --recursive --max-line-length=999 OMPython
```

That uses long lines to avoid addition of line breaks. Shorter lines would be nicer in diffs, but automatic line breaks are not optimal in all cases and require manual tweaking.

To see the same commit without whitepsace, append `?w=1`to the commit URL:
https://github.com/OpenModelica/OMPython/commit/ec9f11cb35a1be8f6eb3197999ac7b9e4aed8e8b?w=1
That diff is much smaller and leaves mostly added/removed blank lines.

If those changes are also undesired, some or all E3 rules can be excluded
http://pep8.readthedocs.io/en/stable/intro.html#error-codes