### PR TITLE
remove sys.platform check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,16 +39,13 @@ def generateIDL():
     print("Generated OMPythonIDL files")
 
 
-if sys.platform != 'win32':
-    try:
-        # if we don't have omniidl then don't try to generate OMPythonIDL files.
-        import omniidl
-        hasomniidl = True
-        generateIDL()
-    except ImportError:
-        hasomniidl = False
-else:
+try:
+    # if we don't have omniidl then don't try to generate OMPythonIDL files.
+    import omniidl
     hasomniidl = True
+    generateIDL()
+except ImportError:
+    hasomniidl = False
 
 OMPython_packages = ['OMPython', 'OMPython.OMParser']
 if hasomniidl:


### PR DESCRIPTION
related: #24 
only check whether omniidl can be imported, independent of OS

This is just a suggestion: If people follow the installation instructions in the readme, the `import omniidl` will succeed on Win32, ~~so the result is the same as before~~.
People who on Windows use the Linux pip command from the Readme will at least get a working ZMQ version this way.

Edit:
I just noticed that on win32 the function generateIDL() did not get called. Does it get called elsewhere?