### PR TITLE
Py 2/3 compatible idioms

### DIFF
--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -32,9 +32,12 @@
  Version: 1.0
 """
 
-import sys
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from builtins import int, range
 
-from builtins import int
+import sys
 
 result = dict()
 

--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -34,6 +34,8 @@
 
 import sys
 
+from builtins import int
+
 result = dict()
 
 inner_sets = []
@@ -54,7 +56,7 @@ def bool_from_string(string):
 
 def typeCheck(string):
     """Attempt conversion of string to a usable value"""
-    types = [bool_from_string, int, float, long, dict, str]
+    types = [bool_from_string, int, float, dict, str]
 
     string = string.strip()
 

--- a/OMPython/OMTypedParser.py
+++ b/OMPython/OMTypedParser.py
@@ -35,7 +35,10 @@ __license__ = """
 __status__ = "Prototype"
 __maintainer__ = "https://openmodelica.org"
 
-import sys
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from builtins import int, range
 
 from pyparsing import (
     Combine,
@@ -55,6 +58,7 @@ from pyparsing import (
     replaceWith,
 )
 
+import sys
 
 def convertNumbers(s, l, toks):
     n = toks[0]

--- a/OMPython/OMTypedParser.py
+++ b/OMPython/OMTypedParser.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from builtins import int, range
+
 __author__ = "Martin Sjölund"
 __license__ = """
  This file is part of OpenModelica.
@@ -34,11 +39,6 @@ __license__ = """
 """
 __status__ = "Prototype"
 __maintainer__ = "https://openmodelica.org"
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from builtins import int, range
 
 from pyparsing import (
     Combine,

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -30,6 +30,7 @@ That format is harder to use.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from future.utils import with_metaclass
 from builtins import int, range
 from copy import deepcopy
 from distutils import spawn
@@ -105,8 +106,7 @@ logger_console_handler.setFormatter(logger_formatter)
 logger.addHandler(logger_console_handler)
 
 
-class OMCSessionBase(object):
-    __metaclass__ = abc.ABCMeta
+class OMCSessionBase(with_metaclass(abc.ABCMeta, object)):
 
     def __init__(self, readonly=False):
         self.readonly = readonly
@@ -580,7 +580,7 @@ class OMCSessionZMQ(OMCSessionBase):
 # LIU(Department of Computer Science)
 
 
-class Quantity:
+class Quantity(object):
     """
     To represent quantities details
     """

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -27,6 +27,38 @@ while execute tries to map also output that is not valid Modelica.
 That format is harder to use.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from builtins import int, range
+from copy import deepcopy
+from distutils import spawn
+
+import abc
+import csv
+import getpass
+import logging
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pyparsing
+
+
+if sys.platform == 'darwin':
+    # On Mac let's assume omc is installed here and there might be a broken omniORB installed in a bad place
+    sys.path.append('/opt/local/lib/python2.7/site-packages/')
+    sys.path.append('/opt/openmodelica/lib/python2.7/site-packages/')
+
+# TODO: replace this with the new parser
+from OMPython import OMTypedParser, OMParser
+
 __license__ = """
  This file is part of OpenModelica.
 
@@ -57,35 +89,6 @@ __license__ = """
 
  Version: 1.1
 """
-
-from builtins import int, range
-from copy import deepcopy
-from distutils import spawn
-
-import abc
-import csv
-import getpass
-import logging
-import os
-import platform
-import subprocess
-import sys
-import tempfile
-import time
-import uuid
-import xml.etree.ElementTree as ET
-
-import numpy as np
-import pyparsing
-
-
-if sys.platform == 'darwin':
-    # On Mac let's assume omc is installed here and there might be a broken omniORB installed in a bad place
-    sys.path.append('/opt/local/lib/python2.7/site-packages/')
-    sys.path.append('/opt/openmodelica/lib/python2.7/site-packages/')
-
-# TODO: replace this with the new parser
-from OMPython import OMTypedParser, OMParser
 
 # Logger Defined
 logger = logging.getLogger('OMPython')

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -58,6 +58,10 @@ __license__ = """
  Version: 1.1
 """
 
+from builtins import int, range
+from copy import deepcopy
+from distutils import spawn
+
 import abc
 import csv
 import getpass
@@ -70,9 +74,6 @@ import tempfile
 import time
 import uuid
 import xml.etree.ElementTree as ET
-
-from copy import deepcopy
-from distutils import spawn
 
 import numpy as np
 import pyparsing
@@ -1660,7 +1661,7 @@ class ModelicaSystem(object):
             self.getconn.sendExpression("setCommandLineOptions(\"+generateSymbolicLinearization\")")
             properties = "{}={}, {}={}, {}={}, {}={}, {}={}".format(self.linearizeOptionsNamesList[0], self.linearizeOptionsValuesList[0], self.linearizeOptionsNamesList[1], self.linearizeOptionsValuesList[1], self.linearizeOptionsNamesList[2], self.linearizeOptionsValuesList[2], self.linearizeOptionsNamesList[3], self.linearizeOptionsValuesList[3], self.linearizeOptionsNamesList[4], self.linearizeOptionsValuesList[4])
             x = self.getParameters()
-            getparamvalues = ','.join("%s=%r" % (key, val) for (key, val) in x.iteritems())
+            getparamvalues = ','.join("%s=%r" % (key, val) for (key, val) in list(x.items()))
             override = "-override=" + getparamvalues
             if self.inputFlag:
                 nameVal = self.getInputs()
@@ -1722,7 +1723,7 @@ class ModelicaSystem(object):
 
     def getLinearQuantityInformation(self):
         # function which extracts linearised states, inputs and outputs
-        for i in xrange(len(self.linearquantitiesList)):
+        for i in range(len(self.linearquantitiesList)):
             if (self.linearquantitiesList[i]['alias'] == 'alias'):
                 name = self.linearquantitiesList[i]['Name']
                 if (name[1] == 'x'):

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(name='OMPython',
       packages=OMPython_packages,
       install_requires=[
           # 'omniORB', # Required, but not part of pypi
+          'future',
           'pyparsing',
           'numpy',
           'pyzmq'

--- a/tests/test_OMParser.py
+++ b/tests/test_OMParser.py
@@ -1,5 +1,7 @@
 import unittest
 
+from builtins import int
+
 from OMPython import OMParser
 
 typeCheck = OMParser.typeCheck
@@ -20,12 +22,11 @@ class TypeCheckTester(unittest.TestCase):
     def testInt(self):
         self.assertEqual(typeCheck('2'), 2)
         self.assertEqual(type(typeCheck('1')), int)
+        self.assertEqual(type(typeCheck('123123123123123123232323')), int)
+        self.assertEqual(type(typeCheck('9223372036854775808')), int)
 
     def testFloat(self):
         self.assertEqual(type(typeCheck('1.2e3')), float)
-
-    def testLong(self):
-        self.assertEqual(type(typeCheck('123123123123123123232323')), long)
 
     # def testDict(self):
     #     self.assertEqual(type(typeCheck('{"a": "b"}')), dict)

--- a/tests/test_OMParser.py
+++ b/tests/test_OMParser.py
@@ -1,8 +1,11 @@
-import unittest
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from builtins import int
 
 from OMPython import OMParser
+
+import unittest
 
 typeCheck = OMParser.typeCheck
 


### PR DESCRIPTION
long is gone in Py3
https://docs.python.org/3.0/whatsnew/3.0.html#integers
use int instead, as explained on
http://python-future.org/compatible_idioms.html#long-integers

Does the line 
`from builtins import int`
have to be added to all other files as well?

@alchemyst You wrote that one test:
https://github.com/OpenModelica/OMPython/blame/master/tests/test_OMParser.py
Could you also review this PR, or the test part?