### PR TITLE
Add support for loading old OMC versions again

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.openmodelica.org/build-deps
+
+RUN apt-get update \
+  && apt-get install -qy gnupg wget ca-certificates apt-transport-https sudo \
+  && echo "deb https://build.openmodelica.org/apt `lsb_release -sc`  release" > /etc/apt/sources.list.d/openmodelica.list \
+  && wget https://build.openmodelica.org/apt/openmodelica.asc -O- | apt-key add - \
+  && apt-get update \
+  && apt-get install -qy --no-install-recommends omc \
+  && pip2 install pytest \
+  && pip3 install pytest \
+  && rm -rf /var/lib/apt/lists/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,53 +1,32 @@
 pipeline {
   agent {
-    docker {
+    dockerfile {
       // Large image with full OpenModelica build dependencies; lacks omc and OMPython
-      image 'openmodelica/build-deps'
       label 'linux'
+      dir '.jenkins'
+      additionalBuildArgs  '--pull'
     }
-  }
-  options {
-    disableConcurrentBuilds()
   }
   stages {
-    stage('setup') {
-      steps {
-        sh '''
-# Install the omc package; should only take a few seconds
-apt-get update
-apt-get install -qy gnupg wget ca-certificates apt-transport-https sudo
-echo "deb https://build.openmodelica.org/apt `lsb_release -sc`  release" > /etc/apt/sources.list.d/openmodelica.list
-wget https://build.openmodelica.org/apt/openmodelica.asc -O- | apt-key add -
-apt-get update
-apt-get install -qy --no-install-recommends omc
-'''
-      }
-    }
     stage('build') {
       parallel {
         stage('python2') {
           steps {
-            // OpenModelica does not like running as root
-            sh 'chown -R nobody .'
-            sh 'pip2 install pytest'
-            sh 'sudo -u nobody python2 setup.py build'
+            sh 'python2 setup.py build'
             timeout(3) {
-              sh 'sudo -u nobody py.test -v --junitxml py2.xml tests/*.py'
+              sh 'python2 /usr/local/bin/py.test -v --junitxml py2.xml tests/*.py'
             }
-            sh 'python2 setup.py install'
+            sh 'HOME="$PWD" python2 setup.py install --user'
             junit 'py2.xml'
           }
         }
         stage('python3') {
           steps {
-            // OpenModelica does not like running as root
-            sh 'chown -R nobody .'
-            sh 'pip3 install pytest'
-            sh 'sudo -u nobody python3 setup.py build'
+            sh 'python3 setup.py build'
             timeout(3) {
-              sh 'sudo -u nobody py.test -v --junitxml py3.xml tests/*.py'
+              sh 'python3 /usr/local/bin/py.test -v --junitxml py3.xml tests/*.py'
             }
-            sh 'python3 setup.py install'
+            sh 'HOME="$PWD" python3 setup.py install --user'
             junit 'py3.xml'
           }
         }

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if hasomniidl:
     OMPython_packages.extend(['OMPythonIDL', 'OMPythonIDL._OMCIDL', 'OMPythonIDL._OMCIDL__POA'])
 
 setup(name='OMPython',
-      version='3.0.3',
+      version='3.1.0',
       description='OpenModelica-Python API Interface',
       author='Anand Kalaiarasi Ganeson',
       author_email='ganan642@student.liu.se',

--- a/tests/test_ZMQ.py
+++ b/tests/test_ZMQ.py
@@ -33,5 +33,27 @@ end M;"""
     self.assertNotEqual("", self.om.sendExpression('res.resultFile'))
     self.clean()
 
+class FindBestOMCSession(unittest.TestCase):
+  def __init__(self, *args, **kwargs):
+    super(FindBestOMCSession, self).__init__(*args, **kwargs)
+    self.simpleModel = """model M
+  Real r = time;
+end M;"""
+    self.tmp = tempfile.mkdtemp(prefix='tmpOMPython.extratests')
+    self.origDir = os.getcwd()
+    os.chdir(self.tmp)
+    self.om = OMPython.FindBestOMCSession()
+    os.chdir(self.origDir)
+  def __del__(self):
+    shutil.rmtree(self.tmp, ignore_errors=True)
+    del(self.om)
+  def clean(self):
+    del(self.om)
+    self.om = None
+
+  def testHelloWorldBestOMCSession(self):
+    self.assertEqual("HelloWorld!", self.om.sendExpression('"HelloWorld!"'))
+    self.clean()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Use session=OMPython.FindBestOMCSession() now tries to auto-detect
CORBA or ZMQ, as well as RML-style +d=interactiveCorba.