### PR TITLE
Clarified the error raised when OpenModellica isn't installed

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -107,7 +107,11 @@ logger.addHandler(logger_console_handler)
 
 class OMCSessionHelper():
   def __init__(self):
-    self.omhome = os.environ.get('OPENMODELICAHOME') or os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
+    path_to_omc = spawn.find_executable("omc")
+    if path_to_omc == '':
+      raise ValueError("Cannot find OpenModelica executable, please install from openmodelica.org")
+    else:
+      self.omhome = os.environ.get('OPENMODELICAHOME') or os.path.split(os.path.split(os.path.realpath(path_to_omc))[0])[0]
 
   def _get_omc_path(self):
     try:

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -107,11 +107,12 @@ logger.addHandler(logger_console_handler)
 
 class OMCSessionHelper():
   def __init__(self):
+    # Get the path to the OMC executable, if not installed this will be None
     path_to_omc = spawn.find_executable("omc")
-    if path_to_omc == '':
-      raise ValueError("Cannot find OpenModelica executable, please install from openmodelica.org")
-    else:
+    if path_to_omc:
       self.omhome = os.environ.get('OPENMODELICAHOME') or os.path.split(os.path.split(os.path.realpath(path_to_omc))[0])[0]
+    else:
+      raise ValueError("Cannot find OpenModelica executable, please install from openmodelica.org")
 
   def _get_omc_path(self):
     try:

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -109,8 +109,11 @@ class OMCSessionHelper():
   def __init__(self):
     # Get the path to the OMC executable, if not installed this will be None
     path_to_omc = spawn.find_executable("omc")
-    if path_to_omc:
-      self.omhome = os.environ.get('OPENMODELICAHOME') or os.path.split(os.path.split(os.path.realpath(path_to_omc))[0])[0]
+    omc_env_home = os.environ.get('OPENMODELICAHOME')
+    if omc_env_home:
+      self.omhome = omc_env_home
+    elif path_to_omc:
+      self.omhome = os.path.split(os.path.split(os.path.realpath(path_to_omc))[0])[0]
     else:
       raise ValueError("Cannot find OpenModelica executable, please install from openmodelica.org")
 


### PR DESCRIPTION
While trying to use OMPython within a Jessie docker container, I forgot to install OpenModelica before trying to run it within Python3 and the error raised was not intuitive that this was the issue which took some digging through the code to figure this out. The error looked like this:
```
>>> omc = OMCSessionZMQ()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/site-packages/OMPython/__init__.py", line 526, in __init__
    OMCSessionHelper.__init__(self)
  File "/usr/local/lib/python3.5/site-packages/OMPython/__init__.py", line 110, in __init__
    self.omhome = os.environ.get('OPENMODELICAHOME') or os.path.split(os.path.split(os.path.realpath(spawn.find_executable("omc")))[0])[0]
  File "/usr/local/lib/python3.5/posixpath.py", line 373, in realpath
    path, ok = _joinrealpath(filename[:0], filename, {})
TypeError: 'NoneType' object is not subscriptable
```
This change will tell the user in this situation to go to openmodelica.org to install OpenModelica:
`Cannot find OpenModelica executable, please install from openmodelica.org`

Also, the text [online mentioning that OpenModelica needs to be install separately](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/ompython.html) from OMPython in order for it to work is easy to miss since its at then end of a paragraph, I think it needs to be highlighted more, either put at the top or put in the section with "To install OMPython follow the instructions at..." 