### PR TITLE
in typeCheck() return value if int or float

### DIFF
--- a/OMPython/OMParser/__init__.py
+++ b/OMPython/OMParser/__init__.py
@@ -61,6 +61,9 @@ def typeCheck(string):
     """Attempt conversion of string to a usable value"""
     types = [bool_from_string, int, float, dict, str]
 
+    if type(string) in {int, float}:
+        return string
+
     string = string.strip()
 
     for t in types:


### PR DESCRIPTION
Fixes error when running generate_icons.py
```
2018-10-02 13:07:41,266 - generate_icons.py - CRITICAL - Failed to generate icons for AixLib.Fluid.FMI.Conversion.AirToOutlet after 17.0 seconds: 'newint' object has no attribute 'strip'
Traceback (most recent call last):
  File "generate_icons.py", line 1298, in <module>
    sys.exit(main())
  File "generate_icons.py", line 1263, in main
    dwg = exportIcon(modelica_class, base_classes, includeInvisibleText, warn_duplicates)
  File "generate_icons.py", line 1156, in exportIcon
    graphics = getGraphicsWithPortsForClass(modelicaClass)
  File "generate_icons.py", line 337, in getGraphicsWithPortsForClass
    comp_annotation = ask_omc('getNthComponentAnnotation', modelicaClass + ', ' + str(comp_id))['SET2']['Set1']
  File "generate_icons.py", line 118, in ask_omc
    res = omc.execute(expression)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/__init__.py", line 591, in execute
    answer = OMParser.check_for_values(result)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/OMParser/__init__.py", line 902, in check_for_values
    check_for_values(next_set)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/OMParser/__init__.py", line 891, in check_for_values
    make_elements(current_set)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/OMParser/__init__.py", line 527, in make_elements
    make_values(element_str, name)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/OMParser/__init__.py", line 168, in make_values
    each_v = typeCheck(each_v)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/OMPython/OMParser/__init__.py", line 64, in typeCheck
    string = string.strip()
AttributeError: 'newint' object has no attribute 'strip'
```