### PR TITLE
Replaced deprecated 'getchildren' method with 'list(elem)' for Python >= 3.2

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -959,7 +959,7 @@ class ModelicaSystem(object):
                 scalar["causality"] = sv.get('causality')
                 scalar["alias"] = sv.get('alias')
                 scalar["aliasvariable"] = sv.get('aliasVariable')
-                ch = sv.getchildren()
+                ch = list(sv)
                 start = None
                 for att in ch:
                     start = att.get('start')


### PR DESCRIPTION
See:
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren

The `getchildren` method within `xml.etree` was deprecated since Python3.2, as of Python3.9 the method has now been removed This patch applies the suggestion given above.