### PR TITLE
update getParameters when rebuilding model

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -968,7 +968,10 @@ class ModelicaSystem(object):
 
                 if(self.linearizationFlag==False):
                     if(scalar["variability"]=="parameter"):
-                        self.paramlist[scalar["name"]]=scalar["start"]
+                        if scalar["name"] in self.overridevariables:
+                            self.paramlist[scalar["name"]] = self.overridevariables[scalar["name"]]
+                        else:
+                            self.paramlist[scalar["name"]] = scalar["start"]
                     if(scalar["variability"]=="continuous"):
                         self.continuouslist[scalar["name"]]=scalar["start"]
                     if(scalar["causality"]=="input"):


### PR DESCRIPTION
### Purpose
This PR fixes the bug in `getParameters() ` with new values set by users using `setParameters() `API. after rebuilding the model using `buildModel()`. 

### Example

```
from OMPython import ModelicaSystem
omc= ModelicaSystem("Test.mo", "Test.Example")
omc.getParameters()
## use the setParameters() API 
omc.setParameters("c=9")
omc.buildModel
omc.simulate()
c = omc.getParameters("c")
```
### output
`c  = 9 
`