### PR TITLE
"outputFormat" in simulateOptions

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -975,6 +975,7 @@ class ModelicaSystem(object):
                 self.simulateOptions["stepSize"] = attr.get('stepSize')
                 self.simulateOptions["tolerance"] = attr.get('tolerance')
                 self.simulateOptions["solver"] = attr.get('solver')
+                self.simulateOptions["outputFormat"] = attr.get('outputFormat')
 
             for sv in rootCQ.iter('ScalarVariable'):
                 scalar={}


### PR DESCRIPTION
### Related Issues

This pull request is related to issue [151](https://github.com/OpenModelica/OMPython/issues/151).

### Purpose

- Enable the use of outputFormat in the simulationOptions

### Approach

Addition of the following line in xmlparse method: 
`self.simulateOptions["outputFormat"] = attr.get('outputFormat')
`