### PR TITLE
parse min and max attribute

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -988,9 +988,15 @@ class ModelicaSystem(object):
                 scalar["aliasvariable"] = sv.get('aliasVariable')
                 ch = list(sv)
                 start = None
+                min = None
+                max = None
                 for att in ch:
                     start = att.get('start')
+                    min = att.get('min')
+                    max = att.get('max')
                 scalar["start"] =start
+                scalar["min"] = min
+                scalar["max"] = max
 
                 if(self.linearizationFlag==False):
                     if(scalar["variability"]=="parameter"):


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMPython/issues/169
### Purpose

This PR parse the `min` and `max` attribute from init.xml
