### PR TITLE
add nightly builds and schedule FMIRegression test every day

### DIFF
--- a/.github/workflows/FMITest.yml
+++ b/.github/workflows/FMITest.yml
@@ -3,7 +3,7 @@ name: FMITest
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * FRI"
+    - cron: "0 9 * * *"
 
 jobs:
   test:
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.10']
         os: ['ubuntu-latest', 'windows-latest']
-        omc-version: ['stable']
+        omc-version: ['stable', 'nightly']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11414

### Purpose

Add nightly builds to github actions and schedule the FMI_Regression test everyday at 9.00 am 
