### PR TITLE
use directly buildModelFMU() for FMI_Regression tests

### DIFF
--- a/tests/test_FMIRegression.py
+++ b/tests/test_FMIRegression.py
@@ -9,45 +9,58 @@ according to the documenation of pytest
 """
 class Test_FMIRegression:
 
-    def checkModel(self, modelName):
-        mod = OMPython.ModelicaSystem(modelName=modelName)
-        fileNamePrefix = modelName.split(".")[-1]
-        fmu = mod.convertMo2Fmu(fileNamePrefix=fileNamePrefix)
-        assert True == os.path.exists(fmu)
-        shutil.rmtree(mod.getWorkDirectory(), ignore_errors=True)
-        mod.__del__()
+    def buildModelFMU(self, modelName):
+        omc = OMPython.OMCSessionZMQ()
 
+        ## create a temp dir for each session
+        tempdir = tempfile.mkdtemp()
+        if not os.path.exists(tempdir):
+            return print(tempdir, " cannot be created")
+
+        tempdirExp="".join(["cd(","\"",tempdir,"\"",")"]).replace("\\","/")
+        omc.sendExpression(tempdirExp)
+
+        omc.sendExpression("loadModel(Modelica)")
+        omc.sendExpression("getErrorString()")
+
+        fileNamePrefix = modelName.split(".")[-1]
+        exp = "buildModelFMU(" + modelName + ", fileNamePrefix=\"" + fileNamePrefix  + "\"" + ")"
+
+        fmu = omc.sendExpression(exp)
+        assert True == os.path.exists(fmu)
+
+        omc.__del__()
+        shutil.rmtree(tempdir, ignore_errors= True)
 
     def test_Modelica_Blocks_Examples_Filter(self):
-        self.checkModel("Modelica.Blocks.Examples.Filter")
+        self.buildModelFMU("Modelica.Blocks.Examples.Filter")
 
     def test_Modelica_Blocks_Examples_RealNetwork1(self):
-        self.checkModel("Modelica.Blocks.Examples.RealNetwork1")
+        self.buildModelFMU("Modelica.Blocks.Examples.RealNetwork1")
 
     def test_Modelica_Electrical_Analog_Examples_CauerLowPassAnalog(self):
-        self.checkModel("Modelica.Electrical.Analog.Examples.CauerLowPassAnalog")
+        self.buildModelFMU("Modelica.Electrical.Analog.Examples.CauerLowPassAnalog")
 
     def test_Modelica_Electrical_Digital_Examples_FlipFlop(self):
-        self.checkModel("Modelica.Electrical.Digital.Examples.FlipFlop")
+        self.buildModelFMU("Modelica.Electrical.Digital.Examples.FlipFlop")
 
     def test_Modelica_Mechanics_Rotational_Examples_FirstGrounded(self):
-        self.checkModel("Modelica.Mechanics.Rotational.Examples.FirstGrounded")
+        self.buildModelFMU("Modelica.Mechanics.Rotational.Examples.FirstGrounded")
 
     def test_Modelica_Mechanics_Rotational_Examples_CoupledClutches(self):
-        self.checkModel("Modelica.Mechanics.Rotational.Examples.CoupledClutches")
+        self.buildModelFMU("Modelica.Mechanics.Rotational.Examples.CoupledClutches")
 
     def test_Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum(self):
-        self.checkModel("Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum")
+        self.buildModelFMU("Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum")
 
     def test_Modelica_Mechanics_MultiBody_Examples_Elementary_FreeBody(self):
-        self.checkModel("Modelica.Mechanics.MultiBody.Examples.Elementary.FreeBody")
+        self.buildModelFMU("Modelica.Mechanics.MultiBody.Examples.Elementary.FreeBody")
 
     def test_Modelica_Fluid_Examples_PumpingSystem(self):
-        self.checkModel("Modelica.Fluid.Examples.PumpingSystem")
+        self.buildModelFMU("Modelica.Fluid.Examples.PumpingSystem")
 
     def test_Modelica_Fluid_Examples_TraceSubstances_RoomCO2WithControls(self):
-        self.checkModel("Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls")
+        self.buildModelFMU("Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls")
 
     def test_Modelica_Clocked_Examples_SimpleControlledDrive_ClockedWithDiscreteTextbookController(self):
-        self.checkModel("Modelica.Clocked.Examples.SimpleControlledDrive.ClockedWithDiscreteTextbookController")
-
+        self.buildModelFMU("Modelica.Clocked.Examples.SimpleControlledDrive.ClockedWithDiscreteTextbookController")


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11414

### Purpose

Use directly `buildModelFMU()` API to test the FMI_Regression, to improve the testing time of the fmus. 
