### PR TITLE
fix result file path

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1225,8 +1225,12 @@ class ModelicaSystem(object):
             r=""
             self.resultfile = os.path.join(self.tempdir, self.modelName + "_res.mat").replace("\\", "/")
         else:
-            r=" -r=" + resultfile
-            self.resultfile = resultfile
+            if os.path.exists(resultfile):
+                r=" -r=" + resultfile
+                self.resultfile = resultfile
+            else:
+                r=" -r=" + os.path.join(self.tempdir, resultfile).replace("\\", "/")
+                self.resultfile = os.path.join(self.tempdir, resultfile).replace("\\", "/")
 
         # allow runtime simulation flags from user input
         if(simflags is None):


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMPython/issues/206
### Purpose

This PR fixes the result file path when `resultfile` location is provided by the user. 

### Usage

```
>>> from OMPython import ModelicaSystem
>>> mod = ModelicaSystem("C:/BouncingBall.mo", "BouncingBall")
>>> mod.simulate(resultfile="C:/OPENMODELICAGIT/BouncingBall_res.mat") // path provided by user
LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
LOG_SUCCESS       | info    | The simulation finished successfully.
>>> mod.resultfile
'C:/OPENMODELICAGIT/BouncingBall_res.mat'
>>> mod.getSolutions()
('der(h)', 'der(v)', 'e', 'flying', 'foo', 'g', 'h', 'impact', 'time', 'v', 'v_new')
>>> mod.simulate(resultfile="test.mat") // providing only the file name 
LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
LOG_SUCCESS       | info    | The simulation finished successfully.
>>> mod.getSolutions()
('der(h)', 'der(v)', 'e', 'flying', 'foo', 'g', 'h', 'impact', 'time', 'v', 'v_new')
```


