### PR TITLE
load linearized model directly from file

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -55,6 +55,7 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 import numpy as np
 import pyparsing
+import importlib
 
 
 if sys.platform == 'darwin':
@@ -1766,11 +1767,10 @@ class ModelicaSystem(object):
             # this function is called from the generated python code linearized_model.py at runtime,
             # to improve the performance by directly reading the matrices A, B, C and D from the julia code and avoid building the linearized modelica model
             try:
-                ## add the generated linearfile directory to system path, as running from script does not find the module
+                ## do not add the linearfile directory to path, as multiple execution of linearization will always use the first added path, instead execute the file
                 ## https://github.com/OpenModelica/OMPython/issues/196
-                sys.path.append(os.path.dirname(linearFile))
-                from linearized_model import linearized_model
-                result = linearized_model()
+                module = importlib.machinery.SourceFileLoader("linearized_model", linearFile).load_module()
+                result = module.linearized_model()
                 (n, m, p, x0, u0, A, B, C, D, stateVars, inputVars, outputVars) = result
                 self.linearinputs = inputVars
                 self.linearoutputs = outputVars


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMPython/issues/212

### Purpose

This PR fixes the linearized model loading, by directly using the generated file rather than adding the directory path to system, as multiple execution of linearization of different model always point to the first added directory path.

