### PR TITLE
Changed to use list instead of string for subprocess command.

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1280,6 +1280,7 @@ class ModelicaSystem(object):
         currentDir = os.getcwd()
         if (os.path.exists(getExeFile)):
             cmd = getExeFile + override + csvinput + r + simflags
+            cmd = cmd.split(" ")
             #print(cmd)
             os.chdir(self.tempdir)
             if (platform.system() == "Windows"):


### PR DESCRIPTION
### Related Issues

[<!-- Link to the issues that are solved with this PR. -->](https://github.com/OpenModelica/OMPython/issues/206)

### Purpose

<!--- Describe the problem or feature. -->
Cannot execute the simulate method on linux.

### Approach

<!--- How does this address the problem? -->
Adapting subprocess input.
