### PR TITLE
fix: library import before opening model when model is inside a package

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -860,8 +860,8 @@ class ModelicaSystem(object):
         self.setTempDirectory(customBuildDirectory)
 
         if fileName is not None:
-            self.loadFile(verbose)
             self.loadLibrary(verbose)
+            self.loadFile(verbose)
 
         ## allow directly loading models from MSL without fileName
         if fileName is None and modelName is not None:


### PR DESCRIPTION
### Related Issues

[<!-- Link to the issues that are solved with this PR. -->](https://github.com/OpenModelica/OMPython/issues/218)

### Purpose

When opening a model inside a custom library, it fails because it open the model before loading the library.
I switch the order of imports