### PR TITLE
feat: get unit of scalars in quantitiesList

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -999,13 +999,16 @@ class ModelicaSystem(object):
                 start = None
                 min = None
                 max = None
+                unit = None
                 for att in ch:
                     start = att.get('start')
                     min = att.get('min')
                     max = att.get('max')
+                    unit = att.get('unit')
                 scalar["start"] =start
                 scalar["min"] = min
                 scalar["max"] = max
+                scalar["unit"] = unit
 
                 if(scalar["variability"]=="parameter"):
                     if scalar["name"] in self.overridevariables:


### PR DESCRIPTION
Hi, 
I want to get the parameters and variables in python Quantities.
Therefore I can get the unit by parsing the unit from xml database
Then I do not know how do you want to edit `getContinuous`, `getParameters` and `getSolutions` functions to support Quantities. 
Do you want to have an additional argument in these functions ? 
Or do you prefer to have another function ?

### Purpose

Get the unit of the parameters and variables to return python Quantities


