### PR TITLE
allow ident's in array dimension

### DIFF
--- a/OMPython/OMTypedParser.py
+++ b/OMPython/OMTypedParser.py
@@ -97,13 +97,12 @@ def evaluateExpression(s, loc, toks):
     try:
         # Evaluate the expression safely
         return eval(expr)
-    except Exception as e:
-        print(f"Error evaluating expression: {expr}")
-        return None
+    except NameError:
+        return expr
 
 # Number parsing (supports arithmetic expressions in dimensions) (e.g., {1 + 1, 1})
 arrayDimension = infixNotation(
-    Word(nums),
+    Word(alphas + "_", alphanums + "_") | Word(nums),
     [
         (Word("+-", exact=1), 1, opAssoc.RIGHT),
         (Word("*/", exact=1), 2, opAssoc.LEFT),

--- a/tests/test_ArrayDimension.py
+++ b/tests/test_ArrayDimension.py
@@ -26,6 +26,12 @@ class Test_ArrayDimension:
         result = omc.sendExpression("getComponents(A)")
         assert result[0][-1] == (6,7), f"array dimension does not match the expected value. Got: {result[0][-1]}, Expected: {(6, 7)}"
 
+        omc.sendExpression("loadString(\"model A Integer y = 5; Integer x[y+1,1+8]; end A;\")")
+        omc.sendExpression("getErrorString()")
+
+        result = omc.sendExpression("getComponents(A)")
+        assert result[-1][-1] == ('y+1',9), f"array dimension does not match the expected value. Got: {result[-1][-1]}, Expected: {('y+1', 9)}"
+
         omc.__del__()
         shutil.rmtree(tempdir, ignore_errors= True)
 

--- a/tests/test_ArrayDimension.py
+++ b/tests/test_ArrayDimension.py
@@ -26,7 +26,7 @@ class Test_ArrayDimension:
         result = omc.sendExpression("getComponents(A)")
         assert result[0][-1] == (6,7), f"array dimension does not match the expected value. Got: {result[0][-1]}, Expected: {(6, 7)}"
 
-        omc.sendExpression("loadString(\"model A Integer y = 5; Integer x[y+1,1+8]; end A;\")")
+        omc.sendExpression("loadString(\"model A Integer y = 5; Integer x[y+1,1+9]; end A;\")")
         omc.sendExpression("getErrorString()")
 
         result = omc.sendExpression("getComponents(A)")

--- a/tests/test_ArrayDimension.py
+++ b/tests/test_ArrayDimension.py
@@ -30,7 +30,7 @@ class Test_ArrayDimension:
         omc.sendExpression("getErrorString()")
 
         result = omc.sendExpression("getComponents(A)")
-        assert result[-1][-1] == ('y+1',9), f"array dimension does not match the expected value. Got: {result[-1][-1]}, Expected: {('y+1', 9)}"
+        assert result[-1][-1] == ('y + 1', 10), f"array dimension does not match the expected value. Got: {result[-1][-1]}, Expected: {('y + 1', 10)}"
 
         omc.__del__()
         shutil.rmtree(tempdir, ignore_errors= True)


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMPython/issues/231

### Purpose

Allow literals in array dimension

