### PR TITLE
[ModelicaSystem._run_cmd] remove unused variable

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -946,7 +946,6 @@ class ModelicaSystem(object):
         logger.debug("Run OM command {} in {}".format(cmd, self.tempdir))
 
         if platform.system() == "Windows":
-            omhome = os.path.join(os.environ.get("OPENMODELICAHOME"))
             dllPath = ""
 
             ## set the process environment from the generated .bat file in windows which should have all the dependencies


### PR DESCRIPTION
small cleanup - remove unused variable omhome in ModelicaSystem._run_cmd()
