### PR TITLE
Fix linearize() simflags must start with space

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1651,6 +1651,8 @@ class ModelicaSystem(object):
 
         if simflags is None:
             simflags = ""
+        else:
+            simflags = " " + simflags
 
         if (os.path.exists(getExeFile)):
             cmd = getExeFile + linruntime + override + csvinput + simflags


### PR DESCRIPTION
Previously, the flags supplied by the user in `simflags` would get appended to automatically generated flags without a space in a call like this:
```python3
(A, B, C, D) = mod.linearize(simflags="-r=file.mat")
```
A workaround is to start simflags with a space:
```python3
(A, B, C, D) = mod.linearize(simflags=" -r=file.mat")
```

This PR removes the need for the workaround.