### PR TITLE
Some more code cleanups

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -98,6 +98,10 @@ class DummyPopen():
 
 class OMCSessionBase(metaclass=abc.ABCMeta):
 
+    def __init__(self, readonly=False):
+        self._readonly = readonly
+        self._omc_cache = {}
+
     def clearOMParserResult(self):
         OMParser.result = {}
 
@@ -125,10 +129,10 @@ class OMCSessionBase(metaclass=abc.ABCMeta):
     def ask(self, question, opt=None, parsed=True):
         p = (question, opt, parsed)
 
-        if self.readonly and question != 'getErrorString':
+        if self._readonly and question != 'getErrorString':
             # can use cache if readonly
-            if p in self.omc_cache:
-                return self.omc_cache[p]
+            if p in self._omc_cache:
+                return self._omc_cache[p]
 
         if opt:
             expression = f'{question}({opt})'
@@ -144,7 +148,7 @@ class OMCSessionBase(metaclass=abc.ABCMeta):
             raise
 
         # save response
-        self.omc_cache[p] = res
+        self._omc_cache[p] = res
 
         return res
 
@@ -329,10 +333,10 @@ class OMCSessionZMQ(OMCSessionBase):
         if dockerExtraArgs is None:
             dockerExtraArgs = []
 
+        super().__init__(readonly=readonly)
+
         self.omhome = self._get_omhome(omhome=omhome)
 
-        self.readonly = readonly
-        self.omc_cache = {}
         self._omc_process = None
         self._omc_command = None
         self._omc = None

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -1465,7 +1465,7 @@ class ModelicaSystem:
         with arguments of https://build.openmodelica.org/Documentation/OpenModelica.Scripting.translateModelFMU.html
         usage
         >>> convertMo2Fmu()
-        >>> convertMo2Fmu(version="2.0", fmuType="me|cs|me_cs", fileNamePrefix="<default>", includeResources=true)
+        >>> convertMo2Fmu(version="2.0", fmuType="me|cs|me_cs", fileNamePrefix="<default>", includeResources=True)
         """
 
         if fileNamePrefix == "<default>":

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -32,11 +32,6 @@ import pathlib
 import warnings
 
 
-if sys.platform == 'darwin':
-    # On Mac let's assume omc is installed here and there might be a broken omniORB installed in a bad place
-    sys.path.append('/opt/local/lib/python2.7/site-packages/')
-    sys.path.append('/opt/openmodelica/lib/python2.7/site-packages/')
-
 # TODO: replace this with the new parser
 from OMPython import OMTypedParser, OMParser
 


### PR DESCRIPTION
additional cleanups which should be added before #257
* Remove unreachable code
* cleanup old code for Python 2.x
* fix OMCSessionBase - the variables self.readonly and self.omc_cache are needed here
* [ModelicaSystem] fix True in docstring
* [OMCSessionBase] fix usage of excaptions - replace ex.message() by ex.msg()
