### PR TITLE
Make `ModelicaSystem.linearize()` return all values

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -39,7 +39,7 @@ __license__ = """
 import logging
 
 from OMPython.OMCSession import OMCSessionBase, OMCSessionZMQ
-from OMPython.ModelicaSystem import ModelicaSystem, ModelicaSystemError
+from OMPython.ModelicaSystem import ModelicaSystem, ModelicaSystemError, LinearizationResult
 
 # Logger Defined
 logger = logging.getLogger('OMPython')
@@ -61,6 +61,7 @@ logger.setLevel(logging.WARNING)
 __all__ = [
     'ModelicaSystem',
     'ModelicaSystemError',
+    'LinearizationResult',
 
     'OMCSessionZMQ',
     'OMCSessionBase',

--- a/tests/test_linearization.py
+++ b/tests/test_linearization.py
@@ -71,7 +71,7 @@ end Pendulum;
         mod.setLinearizationOptions("stopTime=0.02")
         assert mod.getLinearizationOptions("stopTime") == ["0.02"]
 
-        mod.setInputs(["u1=0", "u2=0"])
+        mod.setInputs(["u1=10", "u2=0"])
         [A, B, C, D] = mod.linearize()
         g = float(mod.getParameters("g")[0])
         l = float(mod.getParameters("l")[0])
@@ -82,3 +82,27 @@ end Pendulum;
         assert np.isclose(B, [[0, 0], [0, 1]]).all()
         assert np.isclose(C, [[0.5, 1], [0, 1]]).all()
         assert np.isclose(D, [[1, 0], [1, 0]]).all()
+
+        # test LinearizationResult
+        result = mod.linearize()
+        assert result[0] == A
+        assert result[1] == B
+        assert result[2] == C
+        assert result[3] == D
+        with self.assertRaises(KeyError):
+            result[4]
+
+        A2, B2, C2, D2 = result
+        assert A2 == A
+        assert B2 == B
+        assert C2 == C
+        assert D2 == D
+
+        assert result.n == 2
+        assert result.m == 2
+        assert result.p == 2
+        assert np.isclose(result.x0, [0, np.pi]).all()
+        assert np.isclose(result.u0, [10, 0]).all()
+        assert result.stateVars == ["omega", "phi"]
+        assert result.inputVars == ["u1", "u2"]
+        assert result.outputVars == ["y1", "y2"]


### PR DESCRIPTION
I think it is a shame to get the `x0` and `u0` values from OpenModelica and throw them away without returning them to the user. Thus, I have changed `ModelicaSystem.linearize()` to return a dataclass with all the available information.

To avoid breaking code that relies on the old return value, I have made it possible to unpack the dataclass into `(A,B,C,D)`, as well as to use indexes 0-3 to access the matrices.
However, there are still cases where the new return value behaves differently, e.g. if someone passed the old result straight to `json.dumps()`.

An alternative approach would be to preserve the old return value and add a new function:
```python3
def linearize_new([...]) -> LinearizationResult:
    ...

def linearize(*args, **kwargs):
    r = linearize_new(*args, **kwargs)
    return list(r)
```

It is up to you to decide whether changing the return value like this is acceptable. If you decide to go with the alternative approach outlined above, I'll rework this pull request.