### PR TITLE
Remove logging

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -36,26 +36,8 @@ __license__ = """
  CONDITIONS OF OSMC-PL.
 """
 
-import logging
-
 from OMPython.OMCSession import OMCSessionBase, OMCSessionZMQ
 from OMPython.ModelicaSystem import ModelicaSystem, ModelicaSystemError, LinearizationResult
-
-# Logger Defined
-logger = logging.getLogger('OMPython')
-logger.setLevel(logging.DEBUG)
-# create console handler with a higher log level
-logger_console_handler = logging.StreamHandler()
-logger_console_handler.setLevel(logging.INFO)
-
-# create formatter and add it to the handlers
-logger_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger_console_handler.setFormatter(logger_formatter)
-
-# add the handlers to the logger
-logger.addHandler(logger_console_handler)
-logger.setLevel(logging.WARNING)
-
 
 # global names imported if import 'from OMPython import *' is used
 __all__ = [


### PR DESCRIPTION
### Related Issues

logging should be defined in the calling script

reason: the calling script should define how logging is done; if these settings are added here and the caller adds another log handle (with possibly different settings), all log information could be printed twice or not at all

### Approach

* cleanup log definnitions in __ init __.py (first commit)
* the second commit (re)adds the log definition as a method which could be called if needed
