### PR TITLE
Use subprocess.run

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -1062,6 +1062,7 @@ class ModelicaSystem:
             lintime: Override linearOptions["stopTime"] value.
             simflags: A string of extra command line flags for the model
               binary.
+            timeout: Possible timeout for the execution of OM.
 
         Returns:
             A LinearizationResult object is returned. This allows several

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -310,19 +310,13 @@ class ModelicaSystem:
             my_env = None
 
         try:
-            p = subprocess.Popen(cmd, env=my_env, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE, cwd=self.tempdir)
-            stdout, stderr = p.communicate()
-
-            stdout = stdout.decode('ascii').strip()
-            stderr = stderr.decode('ascii').strip()
-            if stderr:
+            cmdres = subprocess.run(cmd, capture_output=True, text=True, env=my_env, cwd=self.tempdir)
+            stdout = cmdres.stdout.strip()
+            stderr = cmdres.stderr.strip()
+            if cmdres.returncode != 0 or stderr:
                 raise ModelicaSystemError(f"Error running command {cmd}: {stderr}")
             if self._verbose and stdout:
                 logger.info("OM output for command %s:\n%s", cmd, stdout)
-            # check process returncode, some errors don't print to stderr
-            if p.wait():
-                raise ModelicaSystemError(f"Error running command {cmd}: nonzero returncode")
         except Exception as e:
             raise ModelicaSystemError(f"Exception {type(e)} running command {cmd}: {e}")
 

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -314,7 +314,9 @@ class ModelicaSystem:
                                     timeout=timeout)
             stdout = cmdres.stdout.strip()
             stderr = cmdres.stderr.strip()
-            if cmdres.returncode != 0 or stderr:
+            if cmdres.returncode != 0:
+                raise ModelicaSystemError(f"Error running command {cmd}: nonzero return code")
+            if stderr:
                 raise ModelicaSystemError(f"Error running command {cmd}: {stderr}")
             if self._verbose and stdout:
                 logger.info("OM output for command %s:\n%s", cmd, stdout)

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -315,7 +315,7 @@ class ModelicaSystem:
             stdout = cmdres.stdout.strip()
             stderr = cmdres.stderr.strip()
             if cmdres.returncode != 0:
-                raise ModelicaSystemError(f"Error running command {cmd}: nonzero return code")
+                raise ModelicaSystemError(f"Error running command {cmd}: return code = {cmdres.returncode}")
             if stderr:
                 raise ModelicaSystemError(f"Error running command {cmd}: {stderr}")
             if self._verbose and stdout:

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -287,7 +287,7 @@ class ModelicaSystem:
     def getWorkDirectory(self):
         return self.tempdir
 
-    def _run_cmd(self, cmd: list):
+    def _run_cmd(self, cmd: list, timeout: Optional[int] = None):
         logger.debug("Run OM command %s in %s", cmd, self.tempdir)
 
         if platform.system() == "Windows":
@@ -310,13 +310,16 @@ class ModelicaSystem:
             my_env = None
 
         try:
-            cmdres = subprocess.run(cmd, capture_output=True, text=True, env=my_env, cwd=self.tempdir)
+            cmdres = subprocess.run(cmd, capture_output=True, text=True, env=my_env, cwd=self.tempdir,
+                                    timeout=timeout)
             stdout = cmdres.stdout.strip()
             stderr = cmdres.stderr.strip()
             if cmdres.returncode != 0 or stderr:
                 raise ModelicaSystemError(f"Error running command {cmd}: {stderr}")
             if self._verbose and stdout:
                 logger.info("OM output for command %s:\n%s", cmd, stdout)
+        except subprocess.TimeoutExpired:
+            raise ModelicaSystemError(f"Timeout running command {repr(cmd)}")
         except Exception as e:
             raise ModelicaSystemError(f"Exception {type(e)} running command {cmd}: {e}")
 
@@ -669,7 +672,7 @@ class ModelicaSystem:
         else:
             return pathlib.Path(self.tempdir) / self.modelName
 
-    def simulate(self, resultfile=None, simflags=None):  # 11
+    def simulate(self, resultfile=None, simflags=None, timeout: Optional[int] = None):  # 11
         """
         This method simulates model according to the simulation options.
         usage
@@ -732,7 +735,7 @@ class ModelicaSystem:
 
         cmd = exe_file.as_posix() + override + csvinput + r + simflags
         cmd = [s for s in cmd.split(' ') if s]
-        self._run_cmd(cmd=cmd)
+        self._run_cmd(cmd=cmd, timeout=timeout)
         self.simulationFlag = True
 
     # to extract simulation results
@@ -1049,7 +1052,8 @@ class ModelicaSystem:
 
         return optimizeResult
 
-    def linearize(self, lintime: Optional[float] = None, simflags: Optional[str] = None) -> LinearizationResult:
+    def linearize(self, lintime: Optional[float] = None, simflags: Optional[str] = None,
+                  timeout: Optional[int] = None) -> LinearizationResult:
         """Linearize the model according to linearOptions.
 
         Args:
@@ -1110,7 +1114,7 @@ class ModelicaSystem:
         else:
             cmd = exe_file.as_posix() + linruntime + override + csvinput + simflags
             cmd = [s for s in cmd.split(' ') if s]
-            self._run_cmd(cmd=cmd)
+            self._run_cmd(cmd=cmd, timeout=timeout)
 
         # code to get the matrix and linear inputs, outputs and states
         linearFile = pathlib.Path(self.tempdir) / "linearized_model.py"


### PR DESCRIPTION
Simplify subprocess.Popen() by using subprocess.run() in ModelicaSystem._run_cmd()

Reason: the added functionality of Popen() is not used at all in this case ...