### PR TITLE
Define omc session cmd

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -46,7 +46,7 @@ import pathlib
 from dataclasses import dataclass
 from typing import Optional
 
-from OMPython.OMCSession import OMCSessionBase, OMCSessionZMQ
+from OMPython.OMCSession import OMCSessionZMQ
 
 # define logger using the current module name as ID
 logger = logging.getLogger(__name__)

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -117,7 +117,7 @@ class ModelicaSystem:
             variableFilter: Optional[str] = None,
             customBuildDirectory: Optional[str | os.PathLike] = None,
             omhome: Optional[str] = None,
-            session: Optional[OMCSessionBase] = None,
+            session: Optional[OMCSessionZMQ] = None,
             build: Optional[bool] = True
             ):
         """Initialize, load and build a model.

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -114,7 +114,7 @@ class OMCSessionBase(metaclass=abc.ABCMeta):
         elif isinstance(opt, list):
             expression = f"{question}({','.join([str(x) for x in opt])})"
         else:
-            raise Exception(f"Invalid definition of options for {repr(question)}: {repr(opt)}")
+            raise OMCSessionException(f"Invalid definition of options for {repr(question)}: {repr(opt)}")
 
         p = (expression, parsed)
 
@@ -127,9 +127,8 @@ class OMCSessionBase(metaclass=abc.ABCMeta):
 
         try:
             res = self.sendExpression(expression, parsed=parsed)
-        except OMCSessionException:
-            logger.error("OMC failed: %s, %s, parsed=%s", question, opt, parsed)
-            raise
+        except OMCSessionException as ex:
+            raise OMCSessionException("OMC _ask() failed: %s (parsed=%s)", expression, parsed) from ex
 
         # save response
         self._omc_cache[p] = res

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -526,6 +526,9 @@ class OMCSessionZMQ:
         if p is not None:
             raise OMCSessionException("Process Exited, No connection with OMC. Create a new instance of OMCSessionZMQ!")
 
+        if self._omc is None:
+            raise OMCSessionException("No OMC running. Create a new instance of OMCSessionZMQ!")
+
         attempts = 0
         while True:
             try:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -265,14 +265,12 @@ class OMCSessionCmd:
     # end getClassNames;
     def getClassNames(self, className=None, recursive=False, qualified=False, sort=False, builtin=False,
                       showProtected=False):
-        value = self._ask(question='getClassNames',
-                          opt=[className] if className else [] + [f'recursive={str(recursive).lower()}',
-                                                                  f'qualified={str(qualified).lower()}',
-                                                                  f'sort={str(sort).lower()}',
-                                                                  f'builtin={str(builtin).lower()}',
-                                                                  f'showProtected={str(showProtected).lower()}']
-                          )
-        return value
+        opt = [className] if className else [] + [f'recursive={str(recursive).lower()}',
+                                                  f'qualified={str(qualified).lower()}',
+                                                  f'sort={str(sort).lower()}',
+                                                  f'builtin={str(builtin).lower()}',
+                                                  f'showProtected={str(showProtected).lower()}']
+        return self._ask(question='getClassNames', opt=opt)
 
 
 class OMCSessionZMQ:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -90,12 +90,6 @@ class OMCSessionCmd:
         self._readonly = readonly
         self._omc_cache = {}
 
-    def execute(self, command):
-        warnings.warn("This function is depreciated and will be removed in future versions; "
-                      "please use sendExpression() instead", DeprecationWarning, stacklevel=1)
-
-        return self.sendExpression(command, parsed=False)
-
     def _ask(self, question: str, opt: Optional[list[str]] = None, parsed: Optional[bool] = True):
 
         if opt is None:
@@ -515,6 +509,12 @@ class OMCSessionZMQ:
         self._omc.setsockopt(zmq.LINGER, 0)  # Dismisses pending messages if closed
         self._omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
         self._omc.connect(self._port)
+
+    def execute(self, command):
+        warnings.warn("This function is depreciated and will be removed in future versions; "
+                      "please use sendExpression() instead", DeprecationWarning, stacklevel=1)
+
+        return self.sendExpression(command, parsed=False)
 
     def sendExpression(self, command, parsed=True):
         p = self._omc_process.poll()  # check if process is running

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -90,9 +90,6 @@ class OMCSessionCmd:
         self._readonly = readonly
         self._omc_cache = {}
 
-    def sendExpression(self, command, parsed=True):
-        return self._session.sendExpression(command=command, parsed=parsed)
-
     def _ask(self, question: str, opt: Optional[list[str]] = None, parsed: Optional[bool] = True):
 
         if opt is None:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -186,9 +186,11 @@ class OMCSessionCmd:
         try:
             return self._ask(question='getClassComment', opt=[className])
         except pyparsing.ParseException as ex:
-            logger.warning("Method 'getClassComment' failed for %s", className)
-            logger.warning('OMTypedParser error: %s', ex.msg)
+            logger.warning("Method 'getClassComment(%s)' failed; OMTypedParser error: %s",
+                           className, ex.msg)
             return 'No description available'
+        except OMCSessionException:
+            raise
 
     def getNthComponent(self, className, comp_id):
         """ returns with (type, name, description) """
@@ -217,13 +219,18 @@ class OMCSessionCmd:
             logger.warning('OMPython error: %s', ex)
             # FIXME: OMC returns with a different structure for empty parameter set
             return []
+        except OMCSessionException:
+            raise
 
     def getParameterValue(self, className, parameterName):
         try:
             return self._ask(question='getParameterValue', opt=[className, parameterName])
         except pyparsing.ParseException as ex:
-            logger.warning('OMTypedParser error: %s', ex.msg)
+            logger.warning("Method 'getParameterValue(%s, %s)' failed; OMTypedParser error: %s",
+                           className, parameterName, ex.msg)
             return ""
+        except OMCSessionException:
+            raise
 
     def getComponentModifierNames(self, className, componentName):
         return self._ask(question='getComponentModifierNames', opt=[className, componentName])

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -273,7 +273,7 @@ class OMCSessionCmd:
 
 class OMCSessionZMQ:
 
-    def __init__(self, readonly=False, timeout=10.00,
+    def __init__(self, timeout=10.00,
                  docker=None, dockerContainer=None, dockerExtraArgs=None, dockerOpenModelicaPath="omc",
                  dockerNetwork=None, port=None, omhome: str = None):
         if dockerExtraArgs is None:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -90,6 +90,9 @@ class OMCSessionCmd:
         self._readonly = readonly
         self._omc_cache = {}
 
+    def sendExpression(self, command, parsed=True):
+        return self._session.sendExpression(command=command, parsed=parsed)
+
     def _ask(self, question: str, opt: Optional[list[str]] = None, parsed: Optional[bool] = True):
 
         if opt is None:

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -36,7 +36,7 @@ __license__ = """
  CONDITIONS OF OSMC-PL.
 """
 
-from OMPython.OMCSession import OMCSessionBase, OMCSessionZMQ, OMCSessionException
+from OMPython.OMCSession import OMCSessionCmd, OMCSessionZMQ, OMCSessionException
 from OMPython.ModelicaSystem import ModelicaSystem, ModelicaSystemError, LinearizationResult
 
 # global names imported if import 'from OMPython import *' is used
@@ -47,5 +47,5 @@ __all__ = [
 
     'OMCSessionException',
     'OMCSessionZMQ',
-    'OMCSessionBase',
+    'OMCSessionCmd',
 ]

--- a/tests/test_OMSessionCmd.py
+++ b/tests/test_OMSessionCmd.py
@@ -1,0 +1,24 @@
+import OMPython
+import unittest
+
+
+class OMCSessionCmdTester(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(OMCSessionCmdTester, self).__init__(*args, **kwargs)
+
+    def test_isPackage(self):
+        omczmq = OMPython.OMCSessionZMQ()
+        omccmd = OMPython.OMCSessionCmd(session=omczmq)
+        assert not omccmd.isPackage('Modelica')
+
+    def test_isPackage2(self):
+        mod = OMPython.ModelicaSystem(modelName="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog",
+                                      lmodel=["Modelica"])
+        omccmd = OMPython.OMCSessionCmd(session=mod.getconn)
+        assert omccmd.isPackage('Modelica')
+
+    # TODO: add more checks ...
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
rename OMCSession base as OMCSessionCmd and restructure it such that it is an independend function which contains only the API calls to OMC (was the final state of PR #270)

based on PR #270, #273, #280 and #281