### PR TITLE
Adding build as argument to ModelicaSystem constructor

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -221,7 +221,7 @@ class ModelicaSystem:
         elif fileName is None and modelName is not None:
             self.loadLibrary(lmodel=self.lmodel)
         
-        if build :
+        if build:
             self.buildModel(variableFilter)
 
     def setCommandLineOptions(self, commandLineOptions: str):

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -148,7 +148,7 @@ class ModelicaSystem:
             session: OMC session to be used. If unspecified, a new session
               will be created.
             build: Boolean controlling whether or not the model should be
-              built when constructor is called. If False, the constructor 
+              built when constructor is called. If False, the constructor
               simply loads the model without compiling.
 
         Examples:
@@ -220,7 +220,7 @@ class ModelicaSystem:
         # allow directly loading models from MSL without fileName
         elif fileName is None and modelName is not None:
             self.loadLibrary(lmodel=self.lmodel)
-        
+
         if build:
             self.buildModel(variableFilter)
 

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -118,6 +118,7 @@ class ModelicaSystem:
             customBuildDirectory: Optional[str | os.PathLike] = None,
             omhome: Optional[str] = None,
             session: Optional[OMCSessionBase] = None
+            build: Optional[bool] = True
             ):
         """Initialize, load and build a model.
 
@@ -146,6 +147,9 @@ class ModelicaSystem:
               session.
             session: OMC session to be used. If unspecified, a new session
               will be created.
+            build: Boolean controlling whether or not the model should be
+              built when constructor is called. If False, the constructor 
+              simply loads the model without compiling.
 
         Examples:
             mod = ModelicaSystem("ModelicaModel.mo", "modelName")
@@ -216,8 +220,9 @@ class ModelicaSystem:
         # allow directly loading models from MSL without fileName
         elif fileName is None and modelName is not None:
             self.loadLibrary(lmodel=self.lmodel)
-
-        self.buildModel(variableFilter)
+        
+        if build :
+            self.buildModel(variableFilter)
 
     def setCommandLineOptions(self, commandLineOptions: str):
         # set commandLineOptions if provided by users

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -117,7 +117,7 @@ class ModelicaSystem:
             variableFilter: Optional[str] = None,
             customBuildDirectory: Optional[str | os.PathLike] = None,
             omhome: Optional[str] = None,
-            session: Optional[OMCSessionBase] = None
+            session: Optional[OMCSessionBase] = None,
             build: Optional[bool] = True
             ):
         """Initialize, load and build a model.


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

Enables the possibility to instanciate a ModelicaSystem object without compiling the Modelica model called, therefore allowing the user to modify values of structural parameters through `mod.sendExpression("setParameterValue(model, parameter, value)", parsed = False)
` and only compiling the model manually with `mod.buildModel()` once the values are modified. This way, we can avoid to compile the model when we call the ModelicaSystem constructor, change structural parameters and have to compile the model again to take the changes in account.

### Approach

A new optional argument `build` is added to the ModelicaSystem constructor, which is a boolean value defaulting to `True`. The `mod.buildModel()` line in constructor is then enclosed in a `if` loop controlled by the value of `build`.