### PR TITLE
[ModelicaSystem] add missing 'raise' keywords for exceptions

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -286,7 +286,7 @@ class ModelicaSystem:
             # set the process environment from the generated .bat file in windows which should have all the dependencies
             batFilePath = pathlib.Path(self.tempdir) / f"{self.modelName}.bat"
             if not batFilePath.exists():
-                ModelicaSystemError("Batch file (*.bat) does not exist " + str(batFilePath))
+                raise ModelicaSystemError("Batch file (*.bat) does not exist " + str(batFilePath))
 
             with open(batFilePath, 'r') as file:
                 for line in file:
@@ -351,7 +351,7 @@ class ModelicaSystem:
 
     def xmlparse(self):
         if not self.xmlFile.exists():
-            ModelicaSystemError(f"XML file not generated: {self.xmlFile}")
+            raise ModelicaSystemError(f"XML file not generated: {self.xmlFile}")
 
         tree = ET.parse(self.xmlFile)
         rootCQ = tree.getroot()
@@ -907,11 +907,11 @@ class ModelicaSystem:
             if isinstance(l, tuple):
                 # if l[0] < float(self.simValuesList[0]):
                 if l[0] < float(self.simulateOptions["startTime"]):
-                    ModelicaSystemError('Input time value is less than simulation startTime')
+                    raise ModelicaSystemError('Input time value is less than simulation startTime')
                 if len(l) != 2:
-                    ModelicaSystemError(f'Value for {l} is in incorrect format!')
+                    raise ModelicaSystemError(f'Value for {l} is in incorrect format!')
             else:
-                ModelicaSystemError('Error!!! Value must be in tuple format')
+                raise ModelicaSystemError('Error!!! Value must be in tuple format')
 
     def createCSVData(self) -> pathlib.Path:
         start_time: float = float(self.simulateOptions["startTime"])

--- a/tests/test_ModelicaSystem.py
+++ b/tests/test_ModelicaSystem.py
@@ -360,13 +360,13 @@ end M_input;
         assert np.isclose(y[-1], 1.0)
 
         # let's try some edge cases
-        mod.setInputs("u1=[(-0.5, 0.0), (1.0, 1)]")
         # unmatched startTime
         with self.assertRaises(OMPython.ModelicaSystemError):
+            mod.setInputs("u1=[(-0.5, 0.0), (1.0, 1)]")
             mod.simulate()
         # unmatched stopTime
-        mod.setInputs("u1=[(0.0, 0.0), (0.5, 1)]")
         with self.assertRaises(OMPython.ModelicaSystemError):
+            mod.setInputs("u1=[(0.0, 0.0), (0.5, 1)]")
             mod.simulate()
 
         # Let's use both inputs, but each one with different number of of


### PR DESCRIPTION
PR #277 did missed some 'raise' keywords for Exceptions; these are added here ...