### PR TITLE
[ModelicaSystem] reorder input (mypy)

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -314,8 +314,8 @@ class ModelicaSystemCmd:
 class ModelicaSystem:
     def __init__(
             self,
-            fileName: Optional[str | os.PathLike] = None,
-            modelName: Optional[str] = None,
+            modelName: str,
+            fileName: Optional[str | os.PathLike | pathlib.Path] = None,
             lmodel: Optional[list[str | tuple[str, str]]] = None,
             commandLineOptions: Optional[str] = None,
             variableFilter: Optional[str] = None,
@@ -330,10 +330,10 @@ class ModelicaSystem:
         xml files, etc.
 
         Args:
-            fileName: Path to the model file. Either absolute or relative to
-              the current working directory.
             modelName: The name of the model class. If it is contained within
               a package, "PackageName.ModelName" should be used.
+            fileName: Path to the model file. Either absolute or relative to
+              the current working directory.
             lmodel: List of libraries to be loaded before the model itself is
               loaded. Two formats are supported for the list elements:
               lmodel=["Modelica"] for just the library name
@@ -421,7 +421,7 @@ class ModelicaSystem:
             self.loadFile(fileName=self.fileName)
 
         # allow directly loading models from MSL without fileName
-        elif fileName is None and modelName is not None:
+        else:
             self.loadLibrary(lmodel=self.lmodel)
 
         if build:

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -314,8 +314,8 @@ class ModelicaSystemCmd:
 class ModelicaSystem:
     def __init__(
             self,
-            modelName: str,
             fileName: Optional[str | os.PathLike | pathlib.Path] = None,
+            modelName: Optional[str] = None,
             lmodel: Optional[list[str | tuple[str, str]]] = None,
             commandLineOptions: Optional[str] = None,
             variableFilter: Optional[str] = None,
@@ -330,10 +330,10 @@ class ModelicaSystem:
         xml files, etc.
 
         Args:
-            modelName: The name of the model class. If it is contained within
-              a package, "PackageName.ModelName" should be used.
             fileName: Path to the model file. Either absolute or relative to
               the current working directory.
+            modelName: The name of the model class. If it is contained within
+              a package, "PackageName.ModelName" should be used.
             lmodel: List of libraries to be loaded before the model itself is
               loaded. Two formats are supported for the list elements:
               lmodel=["Modelica"] for just the library name
@@ -360,8 +360,12 @@ class ModelicaSystem:
             mod = ModelicaSystem("ModelicaModel.mo", "modelName", ["Modelica"])
             mod = ModelicaSystem("ModelicaModel.mo", "modelName", [("Modelica","3.2.3"), "PowerSystems"])
         """
+
         if fileName is None and modelName is None and not lmodel:  # all None
             raise ModelicaSystemError("Cannot create ModelicaSystem object without any arguments")
+
+        if modelName is None:
+            raise ModelicaSystemError("A modelname must be provided (argument modelName)!")
 
         self.quantitiesList = []
         self.paramlist = {}
@@ -421,7 +425,7 @@ class ModelicaSystem:
             self.loadFile(fileName=self.fileName)
 
         # allow directly loading models from MSL without fileName
-        else:
+        elif fileName is None and modelName is not None:
             self.loadLibrary(lmodel=self.lmodel)
 
         if build:

--- a/tests/test_ModelicaSystem.py
+++ b/tests/test_ModelicaSystem.py
@@ -57,7 +57,7 @@ def test_setParameters():
 def test_setSimulationOptions():
     omc = OMPython.OMCSessionZMQ()
     model_path = omc.sendExpression("getInstallationDirectoryPath()") + "/share/doc/omc/testmodels/"
-    mod = OMPython.ModelicaSystem(model_path + "BouncingBall.mo", "BouncingBall")
+    mod = OMPython.ModelicaSystem(fileName=model_path + "BouncingBall.mo", modelName="BouncingBall")
 
     # method 1
     mod.setSimulationOptions("stopTime=1.234")
@@ -88,7 +88,7 @@ def test_relative_path(model_firstorder):
         model_relative = str(model_file)
         assert "/" not in model_relative
 
-        mod = OMPython.ModelicaSystem(model_relative, "M")
+        mod = OMPython.ModelicaSystem(fileName=model_relative, modelName="M")
         assert float(mod.getParameters("a")[0]) == -1
     finally:
         model_file.unlink()  # clean up the temporary file
@@ -145,7 +145,7 @@ der(x) = x*a + b;
 y = der(x);
 end M_getters;
 """)
-    mod = OMPython.ModelicaSystem(model_file.as_posix(), "M_getters")
+    mod = OMPython.ModelicaSystem(fileName=model_file.as_posix(), modelName="M_getters")
 
     q = mod.getQuantities()
     assert isinstance(q, list)
@@ -324,7 +324,7 @@ der(x) = u1 + u2;
 y = x;
 end M_input;
 """)
-    mod = OMPython.ModelicaSystem(model_file.as_posix(), "M_input")
+    mod = OMPython.ModelicaSystem(fileName=model_file.as_posix(), modelName="M_input")
 
     mod.setSimulationOptions("stopTime=1.0")
 

--- a/tests/test_ModelicaSystemCmd.py
+++ b/tests/test_ModelicaSystemCmd.py
@@ -16,7 +16,7 @@ end M;
 
 
 def test_simflags(model_firstorder):
-    mod = OMPython.ModelicaSystem(model_firstorder.as_posix(), "M")
+    mod = OMPython.ModelicaSystem(fileName=model_firstorder.as_posix(), modelName="M")
     mscmd = OMPython.ModelicaSystemCmd(runpath=mod.tempdir, modelname=mod.modelName)
     mscmd.args_set({
         "noEventEmit": None,

--- a/tests/test_linearization.py
+++ b/tests/test_linearization.py
@@ -55,7 +55,7 @@ y1 = y2 + 0.5*omega;
 y2 = phi + u1;
 end Pendulum;
 """)
-    mod = OMPython.ModelicaSystem(model_file.as_posix(), "Pendulum", ["Modelica"])
+    mod = OMPython.ModelicaSystem(fileName=model_file.as_posix(), modelName="Pendulum", lmodel=["Modelica"])
 
     d = mod.getLinearizationOptions()
     assert isinstance(d, dict)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -33,7 +33,7 @@ __OpenModelica_commandLineOptions="+g=Optimica");
 end BangBang2021;
 """)
 
-    mod = OMPython.ModelicaSystem(model_file.as_posix(), "BangBang2021")
+    mod = OMPython.ModelicaSystem(fileName=model_file.as_posix(), modelName="BangBang2021")
 
     mod.setOptimizationOptions(["numberOfIntervals=16", "stopTime=1",
                                 "stepSize=0.001", "tolerance=1e-8"])


### PR DESCRIPTION
Class ModelicaSystem uses several imputs which are all optional; however, modelName must be present.

This PR reorders the inputs such that modelName is the first parameter. This also fixes one of the last mypy warnings.

Please keep in mind, that this is a breaking change - all calls to ModelicaSystem which do not use kwargs will fail!

On top of PR #292