### PR TITLE
Cleanup OMCSessionZMQ

### DIFF
--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -62,7 +62,7 @@ from OMPython.OMParser import om_parser_basic
 logger = logging.getLogger(__name__)
 
 
-class DummyPopen():
+class DummyPopen:
     def __init__(self, pid):
         self.pid = pid
         self.process = psutil.Process(pid)

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -276,7 +276,7 @@ class OMCSessionZMQ:
         if dockerExtraArgs is None:
             dockerExtraArgs = []
 
-        self.omhome = self._get_omhome(omhome=omhome)
+        self._omhome = self._get_omhome(omhome=omhome)
 
         self._omc_process = None
         self._omc_command = None
@@ -349,7 +349,7 @@ class OMCSessionZMQ:
 
     def _start_omc_process(self, timeout):
         if sys.platform == 'win32':
-            omhome_bin = (self.omhome / "bin").as_posix()
+            omhome_bin = (self._omhome / "bin").as_posix()
             my_env = os.environ.copy()
             my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
             self._omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_log_file,
@@ -484,7 +484,7 @@ class OMCSessionZMQ:
         raise OMCSessionException("Cannot find OpenModelica executable, please install from openmodelica.org")
 
     def _get_omc_path(self) -> pathlib.Path:
-        return self.omhome / "bin" / "omc"
+        return self._omhome / "bin" / "omc"
 
     def _connect_to_omc(self, timeout):
         self._omc_zeromq_uri = "file:///" + self._port_file

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -310,9 +310,9 @@ class OMCSessionZMQ:
         self._port_file = ((pathlib.Path("/tmp") if docker else self._temp_dir) / port_file).as_posix()
         self._interactivePort = port
         # set omc executable path and args
-        self._set_omc_command(omc_path_and_args_list=["--interactive=zmq",
-                                                      "--locale=C",
-                                                      f"-z={self._random_string}"])
+        self._omc_command = self._set_omc_command(omc_path_and_args_list=["--interactive=zmq",
+                                                                          "--locale=C",
+                                                                          f"-z={self._random_string}"])
         # start up omc executable, which is waiting for the ZMQ connection
         self._omc_process = self._start_omc_process(timeout)
         # connect to the running omc instance using ZMQ
@@ -414,7 +414,7 @@ class OMCSessionZMQ:
         """
         return 1000 if sys.platform == 'win32' else os.getuid()
 
-    def _set_omc_command(self, omc_path_and_args_list):
+    def _set_omc_command(self, omc_path_and_args_list) -> list:
         """Define the command that will be called by the subprocess module.
 
         On Windows, use the list input style of the subprocess module to
@@ -461,9 +461,9 @@ class OMCSessionZMQ:
         if self._interactivePort:
             extraFlags = extraFlags + ["--interactivePort=%d" % int(self._interactivePort)]
 
-        self._omc_command = omcCommand + omc_path_and_args_list + extraFlags
+        omc_command = omcCommand + omc_path_and_args_list + extraFlags
 
-        return self._omc_command
+        return omc_command
 
     def _get_omhome(self, omhome: str = None):
         # use the provided path

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -288,8 +288,6 @@ class OMCSessionZMQ:
         self._temp_dir = pathlib.Path(tempfile.gettempdir())
         # generate a random string for this session
         self._random_string = uuid.uuid4().hex
-        # omc log file
-        self._omc_log_file = None
         try:
             self._currentUser = getpass.getuser()
             if not self._currentUser:
@@ -308,7 +306,7 @@ class OMCSessionZMQ:
         self._dockerExtraArgs = dockerExtraArgs
         self._dockerOpenModelicaPath = dockerOpenModelicaPath
         self._dockerNetwork = dockerNetwork
-        self._create_omc_log_file("port")
+        self._omc_log_file = self._create_omc_log_file("port")
         self._timeout = timeout
         self._port_file = ((pathlib.Path("/tmp") if docker else self._temp_dir) / self._port_file).as_posix()
         self._interactivePort = port
@@ -339,13 +337,15 @@ class OMCSessionZMQ:
                 self._omc_process.kill()
                 self._omc_process.wait()
 
-    def _create_omc_log_file(self, suffix):
+    def _create_omc_log_file(self, suffix):  # output?
         if sys.platform == 'win32':
             log_filename = f"openmodelica.{suffix}.{self._random_string}.log"
         else:
             log_filename = f"openmodelica.{self._currentUser}.{suffix}.{self._random_string}.log"
         # this file must be closed in the destructor
-        self._omc_log_file = open(self._temp_dir / log_filename, "w+")
+        omc_log_file = open(self._temp_dir / log_filename, "w+")
+
+        return omc_log_file
 
     def _start_omc_process(self, timeout):
         if sys.platform == 'win32':

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -107,8 +107,6 @@ class OMCSessionCmd:
             if p in self._omc_cache:
                 return self._omc_cache[p]
 
-        logger.debug('OMC ask: %s (parsed=%s)', expression, parsed)
-
         try:
             res = self._session.sendExpression(expression, parsed=parsed)
         except OMCSessionException as ex:
@@ -532,6 +530,8 @@ class OMCSessionZMQ:
 
         if self._omc is None:
             raise OMCSessionException("No OMC running. Create a new instance of OMCSessionZMQ!")
+
+        logger.debug("sendExpression(%r, parsed=%r)", command, parsed)
 
         attempts = 0
         while True:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -295,11 +295,6 @@ class OMCSessionZMQ:
             # We are running as a uid not existing in the password database... Pretend we are nobody
             self._currentUser = "nobody"
 
-        # Locating and using the IOR
-        if sys.platform != 'win32' or docker or dockerContainer:
-            self._port_file = "openmodelica." + self._currentUser + ".port." + self._random_string
-        else:
-            self._port_file = "openmodelica.port." + self._random_string
         self._docker = docker
         self._dockerContainer = dockerContainer
         self._dockerExtraArgs = dockerExtraArgs
@@ -307,7 +302,12 @@ class OMCSessionZMQ:
         self._dockerNetwork = dockerNetwork
         self._omc_log_file = self._create_omc_log_file("port")
         self._timeout = timeout
-        self._port_file = ((pathlib.Path("/tmp") if docker else self._temp_dir) / self._port_file).as_posix()
+        # Locating and using the IOR
+        if sys.platform != 'win32' or docker or dockerContainer:
+            port_file = "openmodelica." + self._currentUser + ".port." + self._random_string
+        else:
+            port_file = "openmodelica.port." + self._random_string
+        self._port_file = ((pathlib.Path("/tmp") if docker else self._temp_dir) / port_file).as_posix()
         self._interactivePort = port
         # set omc executable path and args
         self._set_omc_command(omc_path_and_args_list=["--interactive=zmq",

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -504,7 +504,7 @@ class OMCSessionZMQ:
                 self._omc_log_file.close()
                 logger.error("OMC Server did not start. Please start it! Log-file says:\n%s" % open(name).read())
                 raise OMCSessionException(f"OMC Server did not start (timeout={timeout}). "
-                                          "Could not open file {self._port_file}")
+                                          f"Could not open file {self._port_file}")
             time.sleep(timeout / 80.0)
 
         self._port = self._port.replace("0.0.0.0", self._serverIPAddress)

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -284,7 +284,6 @@ class OMCSessionZMQ:
         self._dockerCid = None
         self._serverIPAddress = "127.0.0.1"
         self._interactivePort = None
-        # FIXME: this code is not well written... need to be refactored
         self._temp_dir = pathlib.Path(tempfile.gettempdir())
         # generate a random string for this session
         self._random_string = uuid.uuid4().hex

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -291,11 +291,11 @@ class OMCSessionZMQ:
         omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
         omc.connect(self.omc_process.get_port())
 
-        self.omc_zmq = omc
+        self.omc_zmq: Optional[zmq.Socket[bytes]] = omc
 
         # variables to store compiled re expressions use in self.sendExpression()
-        self._re_log_entries = None
-        self._re_log_raw = None
+        self._re_log_entries: Optional[re.Pattern[str]] = None
+        self._re_log_raw: Optional[re.Pattern[str]] = None
 
     def __del__(self):
         if self.omc_zmq:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -35,6 +35,7 @@ __license__ = """
 """
 
 import getpass
+import io
 import json
 import logging
 import os
@@ -272,25 +273,16 @@ class OMCSessionZMQ:
 
     def __init__(self,
                  timeout: float = 10.00,
-                 docker: Optional[str] = None,
-                 dockerContainer: Optional[int] = None,
-                 dockerExtraArgs: Optional[list] = None,
-                 dockerOpenModelicaPath: str = "omc",
-                 dockerNetwork: Optional[str] = None,
-                 port: Optional[int] = None,
                  omhome: Optional[str] = None):
-        if dockerExtraArgs is None:
-            dockerExtraArgs = []
 
-        self._omhome = self._get_omhome(omhome=omhome)
+        # store variables
+        self._omhome = self._omc_home_get(omhome=omhome)
+        self._timeout = timeout
 
-        self._omc_process = None
-        self._omc_command = None
-        self._omc: Optional[Any] = None
-        self._dockerCid: Optional[int] = None
-        self._serverIPAddress = "127.0.0.1"
-        self._interactivePort = None
-        self._temp_dir = pathlib.Path(tempfile.gettempdir())
+        # variables to store compiled re expressions use in self.sendExpression()
+        self._re_log_entries = None
+        self._re_log_raw = None
+
         # generate a random string for this session
         self._random_string = uuid.uuid4().hex
         try:
@@ -301,38 +293,50 @@ class OMCSessionZMQ:
             # We are running as a uid not existing in the password database... Pretend we are nobody
             self._currentUser = "nobody"
 
-        self._docker = docker
-        self._dockerContainer = dockerContainer
-        self._dockerExtraArgs = dockerExtraArgs
-        self._dockerOpenModelicaPath = dockerOpenModelicaPath
-        self._dockerNetwork = dockerNetwork
-        self._omc_log_file = self._create_omc_log_file("port")
-        self._timeout = timeout
         # Locating and using the IOR
-        if sys.platform != 'win32' or docker or dockerContainer:
-            port_file = "openmodelica." + self._currentUser + ".port." + self._random_string
+        self._temp_dir = pathlib.Path(tempfile.gettempdir())
+        self._omc_file_port = self._temp_dir / self._filename_port(current_user=self._currentUser,
+                                                                   random_str=self._random_string)
+
+        if sys.platform == 'win32':
+            filename_log = f"openmodelica.port.{self._random_string}.log"
         else:
-            port_file = "openmodelica.port." + self._random_string
-        self._port_file = ((pathlib.Path("/tmp") if docker else self._temp_dir) / port_file).as_posix()
-        self._interactivePort = port
+            filename_log = f"openmodelica.{self._currentUser}.port.{self._random_string}.log"
+        self._omc_file_log = self._temp_dir / filename_log
+        # this file must be closed in the destructor
+        self._omc_filehandle_log: Optional[io.TextIOWrapper] = None
+        try:
+            self._omc_filehandle_log = open(self._temp_dir / filename_log, "w+")
+        except OSError as ex:
+            raise OMCSessionException(f"Cannot open log file {self._omc_file_log}.") from ex
+
         # set omc executable path and args
-        self._omc_command = self._set_omc_command(omc_path_and_args_list=["--interactive=zmq",
-                                                                          "--locale=C",
+        self._omc_command = self._omc_command_get(omc_path_and_args_list=["--locale=C",
+                                                                          "--interactive=zmq",
                                                                           f"-z={self._random_string}"])
         # start up omc executable, which is waiting for the ZMQ connection
-        self._omc_process = self._start_omc_process(timeout)
+        self._omc_process = self._omc_process_get(timeout)
         # connect to the running omc instance using ZMQ
-        self._omc_port = self._connect_to_omc(timeout)
+        self._omc_port = self._omc_port_get(timeout)
 
-        self._re_log_entries = None
-        self._re_log_raw = None
+        # Create the ZeroMQ socket and connect to OMC server
+        context = zmq.Context.instance()
+        omc = context.socket(zmq.REQ)
+        omc.setsockopt(zmq.LINGER, 0)  # Dismisses pending messages if closed
+        omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
+        omc.connect(self._omc_port)
+
+        self._omc = omc
 
     def __del__(self):
         try:
             self.sendExpression("quit()")
         except OMCSessionException:
             pass
-        self._omc_log_file.close()
+
+        if self._omc_filehandle_log is not None:
+            self._omc_filehandle_log.close()
+
         try:
             self._omc_process.wait(timeout=2.0)
         except subprocess.TimeoutExpired:
@@ -342,136 +346,41 @@ class OMCSessionZMQ:
                 self._omc_process.kill()
                 self._omc_process.wait()
 
-    def _create_omc_log_file(self, suffix):  # output?
-        if sys.platform == 'win32':
-            log_filename = f"openmodelica.{suffix}.{self._random_string}.log"
+    @staticmethod
+    def _filename_port(current_user: str, random_str: str) -> str:
+        if sys.platform != 'win32':
+            filename = f"openmodelica.{current_user}.port.{random_str}"
         else:
-            log_filename = f"openmodelica.{self._currentUser}.{suffix}.{self._random_string}.log"
-        # this file must be closed in the destructor
-        omc_log_file = open(self._temp_dir / log_filename, "w+")
+            filename = f"openmodelica.port.{random_str}"
 
-        return omc_log_file
+        return filename
 
-    def _start_omc_process(self, timeout):  # output?
+    def _omc_process_get(self, timeout):  # output?
+        my_env = os.environ.copy()
+
         if sys.platform == 'win32':
             omhome_bin = (self._omhome / "bin").as_posix()
-            my_env = os.environ.copy()
             my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
-            omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_log_file,
-                                           stderr=self._omc_log_file, env=my_env)
         else:
             # set the user environment variable so omc running from wsgi has the same user as OMPython
-            my_env = os.environ.copy()
             my_env["USER"] = self._currentUser
-            omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_log_file,
-                                           stderr=self._omc_log_file, env=my_env)
-        if self._docker:
-            for i in range(0, 40):
-                try:
-                    with open(self._dockerCidFile, "r") as fin:
-                        self._dockerCid = fin.read().strip()
-                except IOError:
-                    pass
-                if self._dockerCid:
-                    break
-                time.sleep(timeout / 40.0)
-            try:
-                os.remove(self._dockerCidFile)
-            except FileNotFoundError:
-                pass
-            if self._dockerCid is None:
-                logger.error("Docker did not start. Log-file says:\n%s" % (open(self._omc_log_file.name).read()))
-                raise OMCSessionException("Docker did not start (timeout=%f might be too short especially if you did "
-                                          "not docker pull the image before this command)." % timeout)
 
-        dockerTop = None
-        if self._docker or self._dockerContainer:
-            if self._dockerNetwork == "separate":
-                output = subprocess.check_output(["docker", "inspect", self._dockerCid]).decode().strip()
-                self._serverIPAddress = json.loads(output)[0]["NetworkSettings"]["IPAddress"]
-            for i in range(0, 40):
-                if sys.platform == 'win32':
-                    break
-                dockerTop = subprocess.check_output(["docker", "top", self._dockerCid]).decode().strip()
-                omc_process = None
-                for line in dockerTop.split("\n"):
-                    columns = line.split()
-                    if self._random_string in line:
-                        try:
-                            omc_process = DummyPopen(int(columns[1]))
-                        except psutil.NoSuchProcess:
-                            raise OMCSessionException(
-                                f"Could not find PID {dockerTop} - is this a docker instance spawned "
-                                f"without --pid=host?\nLog-file says:\n{open(self._omc_log_file.name).read()}")
-                        break
-                if omc_process is not None:
-                    break
-                time.sleep(timeout / 40.0)
-            if omc_process is None:
-                raise OMCSessionException("Docker top did not contain omc process %s:\n%s\nLog-file says:\n%s"
-                                          % (self._random_string, dockerTop, open(self._omc_log_file.name).read()))
+        omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_filehandle_log,
+                                       stderr=self._omc_filehandle_log, env=my_env)
         return omc_process
 
-    def _getuid(self):
+    def _omc_command_get(self, omc_path_and_args_list) -> list:
         """
-        The uid to give to docker.
-        On Windows, volumes are mapped with all files are chmod ugo+rwx,
-        so uid does not matter as long as it is not the root user.
+        Define the command that will be called by the subprocess module.
         """
-        return 1000 if sys.platform == 'win32' else os.getuid()
+        omc_command_base = [str(self._omc_path_get())]
 
-    def _set_omc_command(self, omc_path_and_args_list) -> list:
-        """Define the command that will be called by the subprocess module.
-
-        On Windows, use the list input style of the subprocess module to
-        avoid problems resulting from spaces in the path string.
-        Linux, however, only works with the string version.
-        """
-        if (self._docker or self._dockerContainer) and sys.platform == "win32":
-            extraFlags = ["-d=zmqDangerousAcceptConnectionsFromAnywhere"]
-            if not self._interactivePort:
-                raise OMCSessionException("docker on Windows requires knowing which port to connect to. For "
-                                          "dockerContainer=..., the container needs to have already manually exposed "
-                                          "this port when it was started (-p 127.0.0.1:n:n) or you get an error later.")
-        else:
-            extraFlags = []
-        if self._docker:
-            if sys.platform == "win32":
-                p = int(self._interactivePort)
-                dockerNetworkStr = ["-p", "127.0.0.1:%d:%d" % (p, p)]
-            elif self._dockerNetwork == "host" or self._dockerNetwork is None:
-                dockerNetworkStr = ["--network=host"]
-            elif self._dockerNetwork == "separate":
-                dockerNetworkStr = []
-                extraFlags = ["-d=zmqDangerousAcceptConnectionsFromAnywhere"]
-            else:
-                raise OMCSessionException('dockerNetwork was set to %s, but only \"host\" or \"separate\" is allowed')
-            self._dockerCidFile = self._omc_log_file.name + ".docker.cid"
-            omcCommand = (["docker", "run",
-                           "--cidfile", self._dockerCidFile,
-                           "--rm",
-                           "--env", "USER=%s" % self._currentUser,
-                           "--user", str(self._getuid())]
-                          + self._dockerExtraArgs
-                          + dockerNetworkStr
-                          + [self._docker, self._dockerOpenModelicaPath])
-        elif self._dockerContainer:
-            omcCommand = (["docker", "exec",
-                           "--env", "USER=%s" % self._currentUser,
-                           "--user", str(self._getuid())]
-                          + self._dockerExtraArgs
-                          + [self._dockerContainer, self._dockerOpenModelicaPath])
-            self._dockerCid = self._dockerContainer
-        else:
-            omcCommand = [str(self._get_omc_path())]
-        if self._interactivePort:
-            extraFlags = extraFlags + ["--interactivePort=%d" % int(self._interactivePort)]
-
-        omc_command = omcCommand + omc_path_and_args_list + extraFlags
+        omc_command = omc_command_base + omc_path_and_args_list
 
         return omc_command
 
-    def _get_omhome(self, omhome: Optional[str] = None):
+    @staticmethod
+    def _omc_home_get(omhome: Optional[str] = None):
         # use the provided path
         if omhome is not None:
             return pathlib.Path(omhome)
@@ -488,51 +397,44 @@ class OMCSessionZMQ:
 
         raise OMCSessionException("Cannot find OpenModelica executable, please install from openmodelica.org")
 
-    def _get_omc_path(self) -> pathlib.Path:
+    def _omc_path_get(self) -> pathlib.Path:
         return self._omhome / "bin" / "omc"
 
-    def _connect_to_omc(self, timeout) -> str:
-        omc_zeromq_uri = "file:///" + self._port_file
+    def _omc_port_get(self, timeout) -> str:
+        omc_zeromq_uri = "file:///" + self._omc_file_port.as_posix()
         # See if the omc server is running
         attempts = 0
-        port = None
         while True:
-            if self._dockerCid:
-                try:
-                    port = subprocess.check_output(args=["docker",
-                                                         "exec", str(self._dockerCid),
-                                                         "cat", str(self._port_file)],
-                                                   stderr=subprocess.DEVNULL).decode().strip()
-                    break
-                except subprocess.CalledProcessError:
-                    pass
-            else:
-                if os.path.isfile(self._port_file):
-                    # Read the port file
-                    with open(self._port_file, 'r') as f_p:
-                        port = f_p.readline()
-                    os.remove(self._port_file)
-                    break
+            port = self._omc_port_get_main()
+            if port is not None:
+                break
 
             attempts += 1
             if attempts == 80.0:
-                name = self._omc_log_file.name
-                self._omc_log_file.close()
-                logger.error("OMC Server did not start. Please start it! Log-file says:\n%s" % open(name).read())
+                if self._omc_filehandle_log is not None:
+                    name = self._omc_filehandle_log.name
+                    self._omc_filehandle_log.close()
+                    self._omc_filehandle_log = None
+                    log_content = open(name).read()
+                else:
+                    log_content = '(missing log file)'
                 raise OMCSessionException(f"OMC Server did not start (timeout={timeout}). "
-                                          f"Could not open file {self._port_file}")
+                                          f"Could not open file {self._omc_file_port.as_posix()}. "
+                                          f"Log-file says:\n{log_content}")
             time.sleep(timeout / 80.0)
 
-        port = port.replace("0.0.0.0", self._serverIPAddress)
         logger.info(f"OMC Server is up and running at {omc_zeromq_uri} "
-                    f"pid={self._omc_process.pid if self._omc_process else '?'} cid={self._dockerCid}")
+                    f"pid={self._omc_process.pid if self._omc_process else '?'}")
 
-        # Create the ZeroMQ socket and connect to OMC server
-        context = zmq.Context.instance()
-        self._omc = context.socket(zmq.REQ)
-        self._omc.setsockopt(zmq.LINGER, 0)  # Dismisses pending messages if closed
-        self._omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
-        self._omc.connect(port)
+        return port
+
+    def _omc_port_get_main(self) -> Optional[str]:
+        port = None
+        if self._omc_file_port.is_file():
+            # Read the port file
+            with open(self._omc_file_port, 'r') as f_p:
+                port = f_p.readline()
+            self._omc_file_port.unlink()
 
         return port
 
@@ -561,9 +463,9 @@ class OMCSessionZMQ:
                 pass
             attempts += 1
             if attempts >= 50:
-                self._omc_log_file.seek(0)
-                log = self._omc_log_file.read()
-                self._omc_log_file.close()
+                self._omc_filehandle_log.seek(0)
+                log = self._omc_filehandle_log.read()
+                self._omc_filehandle_log.close()
                 raise OMCSessionException(f"No connection with OMC (timeout={self._timeout}). Log-file says: \n{log}")
             time.sleep(self._timeout / 50.0)
         if command == "quit()":

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -315,10 +315,6 @@ class OMCSessionZMQ:
         return self.sendExpression(command, parsed=False)
 
     def sendExpression(self, command: str, parsed: bool = True):
-        p = self.omc_process.poll()  # check if process is running
-        if p is not None:
-            raise OMCSessionException("Process Exited, No connection with OMC. Create a new instance of OMCSessionZMQ!")
-
         if self.omc_zmq is None:
             raise OMCSessionException("No OMC running. Create a new instance of OMCSessionZMQ!")
 

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -276,6 +276,8 @@ class OMCSessionZMQ:
                  omhome: Optional[str] = None,
                  omc_process: Optional[OMCProcess] = None):
 
+        self._timeout = timeout
+
         if omc_process is None:
             omc_process = OMCProcessLocal(omhome=omhome, timeout=timeout)
         elif not isinstance(omc_process, OMCProcess):

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -333,10 +333,8 @@ class OMCSessionZMQ:
                 pass
             attempts += 1
             if attempts >= 50:
-                self._omc_filehandle_log.seek(0)
-                log = self._omc_filehandle_log.read()
-                self._omc_filehandle_log.close()
-                raise OMCSessionException(f"No connection with OMC (timeout={self._timeout}). Log-file says: \n{log}")
+                raise OMCSessionException(f"No connection with OMC (timeout={self._timeout}). "
+                                          f"Log-file says: \n{self.omc_process.get_log()}")
             time.sleep(self._timeout / 50.0)
         if command == "quit()":
             self.omc_zmq.close()
@@ -448,6 +446,17 @@ class OMCProcess:
             raise OMCSessionException(f"Invalid port to connect to OMC process: {self._omc_port}")
         return self._omc_port
 
+    def get_log(self) -> str:
+        # self._omc_filehandle_log.seek(0)
+        # log = self._omc_filehandle_log.read()
+        # self._omc_filehandle_log.close()
+
+        # TODO: handle log; close log at this point? what about the process, etc?
+
+        log = 'unknown'
+
+        return log
+
 
 class OMCProcessDummy(OMCProcess):
 
@@ -513,6 +522,17 @@ class OMCProcessLocal(OMCProcess):
                                "killing the process with pid=%s", self._omc_process.pid)
                 self._omc_process.kill()
                 self._omc_process.wait()
+
+    def get_log(self) -> str:
+        if self._omc_filehandle_log is not None:
+            self._omc_filehandle_log.seek(0)
+            log = self._omc_filehandle_log.read()
+            # TODO: close file here or keep it open?
+            # self._omc_filehandle_log.close()
+        else:
+            log = '(not available)'
+
+        return log
 
     @staticmethod
     def _filename_port(current_user: str, random_str: str) -> str:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -280,31 +280,31 @@ class OMCSessionZMQ:
             omc_process = OMCProcessLocal(omhome=omhome, timeout=timeout)
         elif not isinstance(omc_process, OMCProcess):
             raise OMCSessionException("Invalid definition of the OMC process!")
-        self._omc_process = omc_process
-
-        # variables to store compiled re expressions use in self.sendExpression()
-        self._re_log_entries = None
-        self._re_log_raw = None
+        self.omc_process = omc_process
 
         # Create the ZeroMQ socket and connect to OMC server
         context = zmq.Context.instance()
         omc = context.socket(zmq.REQ)
         omc.setsockopt(zmq.LINGER, 0)  # Dismisses pending messages if closed
         omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
-        omc.connect(self._omc_process.get_port())
+        omc.connect(self.omc_process.get_port())
 
-        self._omc = omc
+        self.omc_zmq = omc
+
+        # variables to store compiled re expressions use in self.sendExpression()
+        self._re_log_entries = None
+        self._re_log_raw = None
 
     def __del__(self):
-        if self._omc:
+        if self.omc_zmq:
             try:
                 self.sendExpression("quit()")
             except OMCSessionException:
                 pass
 
-            del self._omc
+            del self.omc_zmq
 
-        self._omc = None
+        self.omc_zmq = None
 
     def execute(self, command):
         warnings.warn("This function is depreciated and will be removed in future versions; "
@@ -313,11 +313,11 @@ class OMCSessionZMQ:
         return self.sendExpression(command, parsed=False)
 
     def sendExpression(self, command, parsed=True):
-        p = self._omc_process.poll()  # check if process is running
+        p = self.omc_process.poll()  # check if process is running
         if p is not None:
             raise OMCSessionException("Process Exited, No connection with OMC. Create a new instance of OMCSessionZMQ!")
 
-        if self._omc is None:
+        if self.omc_zmq is None:
             raise OMCSessionException("No OMC running. Create a new instance of OMCSessionZMQ!")
 
         logger.debug("sendExpression(%r, parsed=%r)", command, parsed)
@@ -325,7 +325,7 @@ class OMCSessionZMQ:
         attempts = 0
         while True:
             try:
-                self._omc.send_string(str(command), flags=zmq.NOBLOCK)
+                self.omc_zmq.send_string(str(command), flags=zmq.NOBLOCK)
                 break
             except zmq.error.Again:
                 pass
@@ -337,11 +337,11 @@ class OMCSessionZMQ:
                 raise OMCSessionException(f"No connection with OMC (timeout={self._timeout}). Log-file says: \n{log}")
             time.sleep(self._timeout / 50.0)
         if command == "quit()":
-            self._omc.close()
-            self._omc = None
+            self.omc_zmq.close()
+            self.omc_zmq = None
             return None
         else:
-            result = self._omc.recv_string()
+            result = self.omc_zmq.recv_string()
 
             if command == "getErrorString()":
                 # no error handling if 'getErrorString()' is called
@@ -353,8 +353,8 @@ class OMCSessionZMQ:
                     parsed = False
             else:
                 # allways check for error
-                self._omc.send_string('getMessagesStringInternal()', flags=zmq.NOBLOCK)
-                error_raw = self._omc.recv_string()
+                self.omc_zmq.send_string('getMessagesStringInternal()', flags=zmq.NOBLOCK)
+                error_raw = self.omc_zmq.recv_string()
                 # run error handling only if there is something to check
                 if error_raw != "{}\n":
                     if not self._re_log_entries:

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -541,3 +541,170 @@ class OMCSessionZMQ:
                         raise OMCSessionException("Cannot parse OMC result") from ex
             else:
                 return result
+
+
+# noinspection PyPep8Naming
+class OMCSessionZMQDocker(OMCSessionZMQ):
+
+    def __init__(self,
+                 timeout: float = 10.00,
+                 docker: Optional[str] = None,
+                 dockerContainer: Optional[int] = None,
+                 dockerExtraArgs: Optional[list] = None,
+                 dockerOpenModelicaPath: str = "omc",
+                 dockerNetwork: Optional[str] = None,
+                 port: Optional[int] = None,
+                 omhome: Optional[str] = None):
+        super().__init__(timeout=timeout, omhome=omhome)
+
+        if dockerExtraArgs is None:
+            dockerExtraArgs = []
+
+        if docker is None and dockerContainer is None:
+            raise OMCSessionException("One of docker or dockerContainer must be set!")
+
+        self._docker = docker
+        self._dockerContainer = dockerContainer
+        self._dockerExtraArgs = dockerExtraArgs
+        self._dockerOpenModelicaPath = dockerOpenModelicaPath
+        self._dockerNetwork = dockerNetwork
+
+        self._interactivePort = port
+
+        self._dockerCid: Optional[int] = None
+        self._dockerCidFile: Optional[pathlib.Path] = None
+
+    @staticmethod
+    def _filename_port(current_user: str, random_str: str) -> str:
+        filename = f"openmodelica.{current_user}.port.{random_str}"
+
+        return filename
+
+    @staticmethod
+    def _getuid():
+        """
+        The uid to give to docker.
+        On Windows, volumes are mapped with all files are chmod ugo+rwx,
+        so uid does not matter as long as it is not the root user.
+        """
+        return 1000 if sys.platform == 'win32' else os.getuid()
+
+    def _omc_command_get(self, omc_path_and_args_list) -> list:
+        """
+        Define the command that will be called by the subprocess module.
+        """
+        extraFlags = []
+
+        if (self._docker or self._dockerContainer) and sys.platform == "win32":
+            extraFlags = ["-d=zmqDangerousAcceptConnectionsFromAnywhere"]
+            if not self._interactivePort:
+                raise OMCSessionException("docker on Windows requires knowing which port to connect to. For "
+                                          "dockerContainer=..., the container needs to have already manually exposed "
+                                          "this port when it was started (-p 127.0.0.1:n:n) or you get an error later.")
+
+        if self._docker:
+            if sys.platform == "win32":
+                if self._interactivePort is not None and isinstance(self._interactivePort, int):
+                    p = int(self._interactivePort)
+                    dockerNetworkStr = ["-p", "127.0.0.1:%d:%d" % (p, p)]
+                else:
+                    raise OMCSessionException("Missing or invalid interactive port!")
+            elif self._dockerNetwork == "host" or self._dockerNetwork is None:
+                dockerNetworkStr = ["--network=host"]
+            elif self._dockerNetwork == "separate":
+                dockerNetworkStr = []
+                extraFlags = ["-d=zmqDangerousAcceptConnectionsFromAnywhere"]
+            else:
+                raise OMCSessionException(f'dockerNetwork was set to {self._dockerNetwork}, '
+                                          'but only \"host\" or \"separate\" is allowed')
+            self._dockerCidFile = self._omc_file_log.parent / (self._omc_file_log.stem + ".docker.cid")
+
+            omcCommand = (["docker", "run",
+                           "--cidfile", self._dockerCidFile.as_posix(),
+                           "--rm",
+                           "--env", "USER=%s" % self._currentUser,
+                           "--user", str(self._getuid())]
+                          + self._dockerExtraArgs
+                          + dockerNetworkStr
+                          + [self._docker, self._dockerOpenModelicaPath])
+        elif self._dockerContainer:
+            omcCommand = (["docker", "exec",
+                           "--env", "USER=%s" % self._currentUser,
+                           "--user", str(self._getuid())]
+                          + self._dockerExtraArgs
+                          + [self._dockerContainer, self._dockerOpenModelicaPath])
+            self._dockerCid = self._dockerContainer
+        else:
+            raise OMCSessionException("Only for docker!")
+
+        if self._interactivePort:
+            extraFlags = extraFlags + ["--interactivePort=%d" % int(self._interactivePort)]
+
+        omc_command = omcCommand + omc_path_and_args_list + extraFlags
+
+        return omc_command
+
+    def _omc_process_get(self, timeout):  # output?
+        omc_process = super()._omc_process_get(timeout=timeout)
+
+        if self._docker:
+            for i in range(0, 40):
+                try:
+                    with open(self._dockerCidFile, "r") as fin:
+                        self._dockerCid = fin.read().strip()
+                except IOError:
+                    pass
+                if self._dockerCid:
+                    break
+                time.sleep(timeout / 40.0)
+            try:
+                os.remove(self._dockerCidFile)
+            except FileNotFoundError:
+                pass
+            if self._dockerCid is None:
+                logger.error("Docker did not start. Log-file says:\n%s" % (open(self._omc_filehandle_log.name).read()))
+                raise OMCSessionException("Docker did not start (timeout=%f might be too short especially if you did "
+                                          "not docker pull the image before this command)." % timeout)
+
+        if self._docker or self._dockerContainer:
+            dockerTop = None
+            if self._dockerNetwork == "separate":
+                output = subprocess.check_output(["docker", "inspect", self._dockerCid]).decode().strip()
+                self._serverIPAddress = json.loads(output)[0]["NetworkSettings"]["IPAddress"]
+            for i in range(0, 40):
+                if sys.platform == 'win32':
+                    break
+                dockerTop = subprocess.check_output(["docker", "top", self._dockerCid]).decode().strip()
+                omc_process = None
+                for line in dockerTop.split("\n"):
+                    columns = line.split()
+                    if self._random_string in line:
+                        try:
+                            omc_process = DummyPopen(int(columns[1]))
+                        except psutil.NoSuchProcess:
+                            raise OMCSessionException(
+                                f"Could not find PID {dockerTop} - is this a docker instance spawned "
+                                f"without --pid=host?\nLog-file says:\n{open(self._omc_filehandle_log.name).read()}")
+                        break
+                if omc_process is not None:
+                    break
+                time.sleep(timeout / 40.0)
+            if omc_process is None:
+                raise OMCSessionException("Docker top did not contain omc process %s:\n%s\nLog-file says:\n%s"
+                                          % (self._random_string, dockerTop,
+                                             open(self._omc_filehandle_log.name).read()))
+
+        return omc_process
+
+    def _omc_port_get_main(self) -> Optional[str]:
+        port = None
+
+        try:
+            port = subprocess.check_output(args=["docker",
+                                                 "exec", str(self._dockerCid),
+                                                 "cat", self._omc_file_port.as_posix()],
+                                           stderr=subprocess.DEVNULL).decode().strip()
+        except subprocess.CalledProcessError:
+            pass
+
+        return port

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -273,170 +273,38 @@ class OMCSessionZMQ:
 
     def __init__(self,
                  timeout: float = 10.00,
-                 omhome: Optional[str] = None):
+                 omhome: Optional[str] = None,
+                 omc_process: Optional[OMCProcess] = None):
 
-        # store variables
-        self._omhome = self._omc_home_get(omhome=omhome)
-        self._timeout = timeout
+        if omc_process is None:
+            omc_process = OMCProcessLocal(omhome=omhome, timeout=timeout)
+        elif not isinstance(omc_process, OMCProcess):
+            raise OMCSessionException("Invalid definition of the OMC process!")
+        self._omc_process = omc_process
 
         # variables to store compiled re expressions use in self.sendExpression()
         self._re_log_entries = None
         self._re_log_raw = None
-
-        # generate a random string for this session
-        self._random_string = uuid.uuid4().hex
-        try:
-            self._currentUser = getpass.getuser()
-            if not self._currentUser:
-                self._currentUser = "nobody"
-        except KeyError:
-            # We are running as a uid not existing in the password database... Pretend we are nobody
-            self._currentUser = "nobody"
-
-        # Locating and using the IOR
-        self._temp_dir = pathlib.Path(tempfile.gettempdir())
-        self._omc_file_port = self._temp_dir / self._filename_port(current_user=self._currentUser,
-                                                                   random_str=self._random_string)
-
-        if sys.platform == 'win32':
-            filename_log = f"openmodelica.port.{self._random_string}.log"
-        else:
-            filename_log = f"openmodelica.{self._currentUser}.port.{self._random_string}.log"
-        self._omc_file_log = self._temp_dir / filename_log
-        # this file must be closed in the destructor
-        self._omc_filehandle_log: Optional[io.TextIOWrapper] = None
-        try:
-            self._omc_filehandle_log = open(self._temp_dir / filename_log, "w+")
-        except OSError as ex:
-            raise OMCSessionException(f"Cannot open log file {self._omc_file_log}.") from ex
-
-        # set omc executable path and args
-        self._omc_command = self._omc_command_get(omc_path_and_args_list=["--locale=C",
-                                                                          "--interactive=zmq",
-                                                                          f"-z={self._random_string}"])
-        # start up omc executable, which is waiting for the ZMQ connection
-        self._omc_process = self._omc_process_get(timeout)
-        # connect to the running omc instance using ZMQ
-        self._omc_port = self._omc_port_get(timeout)
 
         # Create the ZeroMQ socket and connect to OMC server
         context = zmq.Context.instance()
         omc = context.socket(zmq.REQ)
         omc.setsockopt(zmq.LINGER, 0)  # Dismisses pending messages if closed
         omc.setsockopt(zmq.IMMEDIATE, True)  # Queue messages only to completed connections
-        omc.connect(self._omc_port)
+        omc.connect(self._omc_process.get_port())
 
         self._omc = omc
 
     def __del__(self):
-        try:
-            self.sendExpression("quit()")
-        except OMCSessionException:
-            pass
+        if self._omc:
+            try:
+                self.sendExpression("quit()")
+            except OMCSessionException:
+                pass
 
-        if self._omc_filehandle_log is not None:
-            self._omc_filehandle_log.close()
+            del self._omc
 
-        try:
-            self._omc_process.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            if self._omc_process:
-                logger.warning("OMC did not exit after being sent the quit() command; "
-                               "killing the process with pid=%s", self._omc_process.pid)
-                self._omc_process.kill()
-                self._omc_process.wait()
-
-    @staticmethod
-    def _filename_port(current_user: str, random_str: str) -> str:
-        if sys.platform != 'win32':
-            filename = f"openmodelica.{current_user}.port.{random_str}"
-        else:
-            filename = f"openmodelica.port.{random_str}"
-
-        return filename
-
-    def _omc_process_get(self, timeout):  # output?
-        my_env = os.environ.copy()
-
-        if sys.platform == 'win32':
-            omhome_bin = (self._omhome / "bin").as_posix()
-            my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
-        else:
-            # set the user environment variable so omc running from wsgi has the same user as OMPython
-            my_env["USER"] = self._currentUser
-
-        omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_filehandle_log,
-                                       stderr=self._omc_filehandle_log, env=my_env)
-        return omc_process
-
-    def _omc_command_get(self, omc_path_and_args_list) -> list:
-        """
-        Define the command that will be called by the subprocess module.
-        """
-        omc_command_base = [str(self._omc_path_get())]
-
-        omc_command = omc_command_base + omc_path_and_args_list
-
-        return omc_command
-
-    @staticmethod
-    def _omc_home_get(omhome: Optional[str] = None):
-        # use the provided path
-        if omhome is not None:
-            return pathlib.Path(omhome)
-
-        # check the environment variable
-        omhome = os.environ.get('OPENMODELICAHOME')
-        if omhome is not None:
-            return pathlib.Path(omhome)
-
-        # Get the path to the OMC executable, if not installed this will be None
-        path_to_omc = shutil.which("omc")
-        if path_to_omc is not None:
-            return pathlib.Path(path_to_omc).parents[1]
-
-        raise OMCSessionException("Cannot find OpenModelica executable, please install from openmodelica.org")
-
-    def _omc_path_get(self) -> pathlib.Path:
-        return self._omhome / "bin" / "omc"
-
-    def _omc_port_get(self, timeout) -> str:
-        omc_zeromq_uri = "file:///" + self._omc_file_port.as_posix()
-        # See if the omc server is running
-        attempts = 0
-        while True:
-            port = self._omc_port_get_main()
-            if port is not None:
-                break
-
-            attempts += 1
-            if attempts == 80.0:
-                if self._omc_filehandle_log is not None:
-                    name = self._omc_filehandle_log.name
-                    self._omc_filehandle_log.close()
-                    self._omc_filehandle_log = None
-                    log_content = open(name).read()
-                else:
-                    log_content = '(missing log file)'
-                raise OMCSessionException(f"OMC Server did not start (timeout={timeout}). "
-                                          f"Could not open file {self._omc_file_port.as_posix()}. "
-                                          f"Log-file says:\n{log_content}")
-            time.sleep(timeout / 80.0)
-
-        logger.info(f"OMC Server is up and running at {omc_zeromq_uri} "
-                    f"pid={self._omc_process.pid if self._omc_process else '?'}")
-
-        return port
-
-    def _omc_port_get_main(self) -> Optional[str]:
-        port = None
-        if self._omc_file_port.is_file():
-            # Read the port file
-            with open(self._omc_file_port, 'r') as f_p:
-                port = f_p.readline()
-            self._omc_file_port.unlink()
-
-        return port
+        self._omc = None
 
     def execute(self, command):
         warnings.warn("This function is depreciated and will be removed in future versions; "
@@ -541,6 +409,182 @@ class OMCSessionZMQ:
                         raise OMCSessionException("Cannot parse OMC result") from ex
             else:
                 return result
+
+
+class OMCProcess:
+
+    def __init__(self,
+                 timeout: float = 10.00,
+                 omhome: Optional[str] = None):
+
+        # store variables
+        self._omhome = self._omc_home_get(omhome=omhome)
+        self._timeout = timeout
+
+        self._omc_port: Optional[str] = None
+
+    @staticmethod
+    def _omc_home_get(omhome: Optional[str] = None):
+        # use the provided path
+        if omhome is not None:
+            return pathlib.Path(omhome)
+
+        # check the environment variable
+        omhome = os.environ.get('OPENMODELICAHOME')
+        if omhome is not None:
+            return pathlib.Path(omhome)
+
+        # Get the path to the OMC executable, if not installed this will be None
+        path_to_omc = shutil.which("omc")
+        if path_to_omc is not None:
+            return pathlib.Path(path_to_omc).parents[1]
+
+        raise OMCSessionException("Cannot find OpenModelica executable, please install from openmodelica.org")
+
+    def get_port(self) -> str:
+        if not isinstance(self._omc_port, str):
+            raise OMCSessionException(f"Invalid port to connect to OMC process: {self._omc_port}")
+        return self._omc_port
+
+
+class OMCProcessDummy(OMCProcess):
+
+    def __init__(self,
+                 omc_port: str):
+        super().__init__()
+        self._omc_port = omc_port
+
+
+class OMCProcessLocal(OMCProcess):
+
+    def __init__(self,
+                 timeout: float = 10.00,
+                 omhome: Optional[str] = None):
+
+        super().__init__(timeout=timeout, omhome=omhome)
+
+        # generate a random string for this session
+        self._random_string = uuid.uuid4().hex
+        try:
+            self._currentUser = getpass.getuser()
+            if not self._currentUser:
+                self._currentUser = "nobody"
+        except KeyError:
+            # We are running as a uid not existing in the password database... Pretend we are nobody
+            self._currentUser = "nobody"
+
+        # Locating and using the IOR
+        self._temp_dir = pathlib.Path(tempfile.gettempdir())
+        self._omc_file_port = self._temp_dir / self._filename_port(current_user=self._currentUser,
+                                                                   random_str=self._random_string)
+
+        if sys.platform == 'win32':
+            filename_log = f"openmodelica.port.{self._random_string}.log"
+        else:
+            filename_log = f"openmodelica.{self._currentUser}.port.{self._random_string}.log"
+        self._omc_file_log = self._temp_dir / filename_log
+        # this file must be closed in the destructor
+        self._omc_filehandle_log: Optional[io.TextIOWrapper] = None
+        try:
+            self._omc_filehandle_log = open(self._temp_dir / filename_log, "w+")
+        except OSError as ex:
+            raise OMCSessionException(f"Cannot open log file {self._omc_file_log}.") from ex
+
+        # set omc executable path and args
+        self._omc_command = self._omc_command_get(omc_path_and_args_list=["--locale=C",
+                                                                          "--interactive=zmq",
+                                                                          f"-z={self._random_string}"])
+        # start up omc executable, which is waiting for the ZMQ connection
+        self._omc_process = self._omc_process_get(timeout)
+        # connect to the running omc instance using ZMQ
+        self._omc_port = self._omc_port_get(timeout)
+
+    def __del__(self):
+        if self._omc_filehandle_log is not None:
+            self._omc_filehandle_log.close()
+
+        try:
+            self._omc_process.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            if self._omc_process:
+                logger.warning("OMC did not exit after being sent the quit() command; "
+                               "killing the process with pid=%s", self._omc_process.pid)
+                self._omc_process.kill()
+                self._omc_process.wait()
+
+    @staticmethod
+    def _filename_port(current_user: str, random_str: str) -> str:
+        if sys.platform != 'win32':
+            filename = f"openmodelica.{current_user}.port.{random_str}"
+        else:
+            filename = f"openmodelica.port.{random_str}"
+
+        return filename
+
+    def _omc_process_get(self, timeout):  # output?
+        my_env = os.environ.copy()
+
+        if sys.platform == 'win32':
+            omhome_bin = (self._omhome / "bin").as_posix()
+            my_env["PATH"] = omhome_bin + os.pathsep + my_env["PATH"]
+        else:
+            # set the user environment variable so omc running from wsgi has the same user as OMPython
+            my_env["USER"] = self._currentUser
+
+        omc_process = subprocess.Popen(self._omc_command, stdout=self._omc_filehandle_log,
+                                       stderr=self._omc_filehandle_log, env=my_env)
+        return omc_process
+
+    def _omc_command_get(self, omc_path_and_args_list) -> list:
+        """
+        Define the command that will be called by the subprocess module.
+        """
+        omc_command_base = [str(self._omc_path_get())]
+
+        omc_command = omc_command_base + omc_path_and_args_list
+
+        return omc_command
+
+    def _omc_path_get(self) -> pathlib.Path:
+        return self._omhome / "bin" / "omc"
+
+    def _omc_port_get(self, timeout) -> str:
+        omc_zeromq_uri = "file:///" + self._omc_file_port.as_posix()
+        # See if the omc server is running
+        attempts = 0
+        while True:
+            port = self._omc_port_get_main()
+            if port is not None:
+                break
+
+            attempts += 1
+            if attempts == 80.0:
+                if self._omc_filehandle_log is not None:
+                    name = self._omc_filehandle_log.name
+                    self._omc_filehandle_log.close()
+                    self._omc_filehandle_log = None
+                    log_content = open(name).read()
+                else:
+                    log_content = '(missing log file)'
+                raise OMCSessionException(f"OMC Server did not start (timeout={timeout}). "
+                                          f"Could not open file {self._omc_file_port.as_posix()}. "
+                                          f"Log-file says:\n{log_content}")
+            time.sleep(timeout / 80.0)
+
+        logger.info(f"OMC Server is up and running at {omc_zeromq_uri} "
+                    f"pid={self._omc_process.pid if self._omc_process else '?'}")
+
+        return port
+
+    def _omc_port_get_main(self) -> Optional[str]:
+        port = None
+        if self._omc_file_port.is_file():
+            # Read the port file
+            with open(self._omc_file_port, 'r') as f_p:
+                port = f_p.readline()
+            self._omc_file_port.unlink()
+
+        return port
 
 
 # noinspection PyPep8Naming

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -610,7 +610,7 @@ class OMCProcessLocal(OMCProcess):
 
 
 # noinspection PyPep8Naming
-class OMCSessionZMQDocker(OMCSessionZMQ):
+class OMCProcessDocker(OMCProcessLocal):
 
     def __init__(self,
                  timeout: float = 10.00,

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -306,13 +306,13 @@ class OMCSessionZMQ:
 
         self.omc_zmq = None
 
-    def execute(self, command):
+    def execute(self, command: str):
         warnings.warn("This function is depreciated and will be removed in future versions; "
                       "please use sendExpression() instead", DeprecationWarning, stacklevel=1)
 
         return self.sendExpression(command, parsed=False)
 
-    def sendExpression(self, command, parsed=True):
+    def sendExpression(self, command: str, parsed: bool = True):
         p = self.omc_process.poll()  # check if process is running
         if p is not None:
             raise OMCSessionException("Process Exited, No connection with OMC. Create a new instance of OMCSessionZMQ!")

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -37,7 +37,7 @@ __license__ = """
 """
 
 from OMPython.ModelicaSystem import LinearizationResult, ModelicaSystem, ModelicaSystemCmd, ModelicaSystemError
-from OMPython.OMCSession import OMCSessionCmd, OMCSessionException, OMCSessionZMQ
+from OMPython.OMCSession import OMCSessionCmd, OMCSessionException, OMCSessionZMQ, OMCSessionZMQDocker
 
 # global names imported if import 'from OMPython import *' is used
 __all__ = [
@@ -49,4 +49,5 @@ __all__ = [
     'OMCSessionCmd',
     'OMCSessionException',
     'OMCSessionZMQ',
+    'OMCSessionZMQDocker',
 ]

--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -37,7 +37,7 @@ __license__ = """
 """
 
 from OMPython.ModelicaSystem import LinearizationResult, ModelicaSystem, ModelicaSystemCmd, ModelicaSystemError
-from OMPython.OMCSession import OMCSessionCmd, OMCSessionException, OMCSessionZMQ, OMCSessionZMQDocker
+from OMPython.OMCSession import OMCSessionCmd, OMCSessionException, OMCSessionZMQ, OMCProcessDummy, OMCProcessDocker
 
 # global names imported if import 'from OMPython import *' is used
 __all__ = [
@@ -49,5 +49,5 @@ __all__ = [
     'OMCSessionCmd',
     'OMCSessionException',
     'OMCSessionZMQ',
-    'OMCSessionZMQDocker',
+    'OMCProcessDocker',
 ]

--- a/tests/test_ZMQ.py
+++ b/tests/test_ZMQ.py
@@ -46,6 +46,34 @@ end M;"""
         self.assertEqual('HelloWorld!', self.om.sendExpression('"HelloWorld!"', parsed=True))
         self.clean()
 
+    def test_omcprocessdummy_execute(self):
+        port = self.om.omc_process.get_port()
+        omcp = OMPython.OMCProcessDummy(omc_port=port)
+
+        # run 1
+        om1 = OMPython.OMCSessionZMQ(omc_process=omcp)
+        self.assertEqual('"HelloWorld!"\n', om1.sendExpression('"HelloWorld!"', parsed=False))
+
+        # run 2
+        om2 = OMPython.OMCSessionZMQ(omc_process=omcp)
+        self.assertEqual('"HelloWorld!"\n', om2.sendExpression('"HelloWorld!"', parsed=False))
+
+        del om1
+        del om2
+
+        self.clean()
+
+    def test_omcprocessdummy_simulate(self):
+        port = self.om.omc_process.get_port()
+        omcp = OMPython.OMCProcessDummy(omc_port=port)
+
+        om = OMPython.OMCSessionZMQ(omc_process=omcp)
+        self.assertEqual(True, om.sendExpression('loadString("%s")' % self.simpleModel))
+        om.sendExpression('res:=simulate(M, stopTime=2.0)')
+        self.assertNotEqual("", om.sendExpression('res.resultFile'))
+        del om
+
+        self.clean()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -6,14 +6,25 @@ import pytest
 class DockerTester(unittest.TestCase):
     @pytest.mark.skip(reason="This test would fail")
     def testDocker(self):
-        om = OMPython.OMCSessionZMQDocker(docker="openmodelica/openmodelica:v1.16.1-minimal")
+        omcp = OMPython.OMCProcessDocker(docker="openmodelica/openmodelica:v1.16.1-minimal")
+        om = OMPython.OMCSessionZMQ(omc_process=omcp)
         assert om.sendExpression("getVersion()") == "OpenModelica 1.16.1"
-        omInner = OMPython.OMCSessionZMQDocker(dockerContainer=om._dockerCid)
+
+        omcpInner = OMPython.OMCProcessDocker(dockerContainer=om._dockerCid)
+        omInner = OMPython.OMCSessionZMQ(omc_process=omcpInner)
         assert omInner.sendExpression("getVersion()") == "OpenModelica 1.16.1"
-        om2 = OMPython.OMCSessionZMQDocker(docker="openmodelica/openmodelica:v1.16.1-minimal", port=11111)
+
+        omcp2 = OMPython.OMCProcessDocker(docker="openmodelica/openmodelica:v1.16.1-minimal", port=11111)
+        om2 = OMPython.OMCSessionZMQ(omc_process=omcp2)
         assert om2.sendExpression("getVersion()") == "OpenModelica 1.16.1"
+
+        del omcp2
         del om2
+
+        del omcpInner
         del omInner
+
+        del omcp
         del om
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -6,11 +6,11 @@ import pytest
 class DockerTester(unittest.TestCase):
     @pytest.mark.skip(reason="This test would fail")
     def testDocker(self):
-        om = OMPython.OMCSessionZMQ(docker="openmodelica/openmodelica:v1.16.1-minimal")
+        om = OMPython.OMCSessionZMQDocker(docker="openmodelica/openmodelica:v1.16.1-minimal")
         assert om.sendExpression("getVersion()") == "OpenModelica 1.16.1"
-        omInner = OMPython.OMCSessionZMQ(dockerContainer=om._dockerCid)
+        omInner = OMPython.OMCSessionZMQDocker(dockerContainer=om._dockerCid)
         assert omInner.sendExpression("getVersion()") == "OpenModelica 1.16.1"
-        om2 = OMPython.OMCSessionZMQ(docker="openmodelica/openmodelica:v1.16.1-minimal", port=11111)
+        om2 = OMPython.OMCSessionZMQDocker(docker="openmodelica/openmodelica:v1.16.1-minimal", port=11111)
         assert om2.sendExpression("getVersion()") == "OpenModelica 1.16.1"
         del om2
         del omInner


### PR DESCRIPTION
OMCSessionZMQ handles different tasks:

a) start OMC process (local / via docker / via docker container)
b) connect to OMC process via ZMQ
c) connect to OMC using ZMQ

This PR tries to find a way to to split these items into several classes:

[1] OMCSessionZMQ - for b) and c)
[2] OMCProcess / OMCProcessLocal / OMCProcessDummy / OMCProcessDocker(?) - for a)

I started to work on this due to the docker code just sitting there without much usage in my case. Save for docker, all other test run fine ...

Still work in progress; feel free to comment if this even makes sense ...

On top of PR #291