### PR TITLE
[ModelicaSystem] use absolute path for tempdir

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -473,14 +473,14 @@ class ModelicaSystem:
         if customBuildDirectory is not None:
             if not os.path.exists(customBuildDirectory):
                 raise IOError(customBuildDirectory, " does not exist")
-            tempdir = pathlib.Path(customBuildDirectory)
+            tempdir = pathlib.Path(customBuildDirectory).absolute()
         else:
-            tempdir = pathlib.Path(tempfile.mkdtemp())
+            tempdir = pathlib.Path(tempfile.mkdtemp()).absolute()
             if not tempdir.is_dir():
                 raise IOError(tempdir, " cannot be created")
 
         logger.info("Define tempdir as %s", tempdir)
-        exp = f'cd("{tempdir.absolute().as_posix()}")'
+        exp = f'cd("{tempdir.as_posix()}")'
         self.sendExpression(exp)
 
         return tempdir


### PR DESCRIPTION
small change to define (and use) an absolute path for tempdir - during my testing I got some corner cases there ModelicaSystem failed due to relative paths in tempdir