### PR TITLE
[ModelicaSystem] only local omc process allowed

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -49,7 +49,7 @@ from typing import Optional, Any
 import warnings
 import xml.etree.ElementTree as ET
 
-from OMPython.OMCSession import OMCSessionException, OMCSessionZMQ
+from OMPython.OMCSession import OMCSessionException, OMCSessionZMQ, OMCProcessLocal
 
 # define logger using the current module name as ID
 logger = logging.getLogger(__name__)
@@ -303,7 +303,7 @@ class ModelicaSystem:
             variableFilter: Optional[str] = None,
             customBuildDirectory: Optional[str | os.PathLike | pathlib.Path] = None,
             omhome: Optional[str] = None,
-            session: Optional[OMCSessionZMQ] = None,
+            omc_process: Optional[OMCProcessLocal] = None,
             build: bool = True,
     ) -> None:
         """Initialize, load and build a model.
@@ -331,8 +331,8 @@ class ModelicaSystem:
               directory will be created.
             omhome: OPENMODELICAHOME value to be used when creating the OMC
               session.
-            session: OMC session to be used. If unspecified, a new session
-              will be created.
+            omc_process: definition of a (local) OMC process to be used. If
+              unspecified, a new local session will be created.
             build: Boolean controlling whether or not the model should be
               built when constructor is called. If False, the constructor
               simply loads the model without compiling.
@@ -367,10 +367,10 @@ class ModelicaSystem:
         self._linearized_outputs: list[str] = []  # linearization output list
         self._linearized_states: list[str] = []  # linearization states list
 
-        if session is not None:
-            if not isinstance(session, OMCSessionZMQ):
-                raise ModelicaSystemError("Invalid session data provided!")
-            self._getconn = session
+        if omc_process is not None:
+            if not isinstance(omc_process, OMCProcessLocal):
+                raise ModelicaSystemError("Invalid (local) omc process definition provided!")
+            self._getconn = OMCSessionZMQ(omc_process=omc_process)
         else:
             self._getconn = OMCSessionZMQ(omhome=omhome)
 


### PR DESCRIPTION
ModelicaSystem relies on read access to files and the possibility to execute the compiled model; thus, it *only* works if OMC is started locally

Use OMCProcessLocal to ensure that this requirement is defined

Based on PR #295