### PR TITLE
ModelicaSystem getSolution

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -950,14 +950,18 @@ class ModelicaSystem:
         >>> getSolutions(["Name1","Name2"],resultfile=""c:/a.mat"")
         """
         if resultfile is None:
-            resFile = self.resultfile.as_posix()
+            result_file = self.resultfile
         else:
-            resFile = resultfile
+            result_file = pathlib.Path(resultfile)
 
         # check for result file exits
-        if not os.path.exists(resFile):
-            raise ModelicaSystemError(f"Result file does not exist {resFile}")
-        resultVars = self.sendExpression(f'readSimulationResultVars("{resFile}")')
+        if not result_file.is_file():
+            raise ModelicaSystemError(f"Result file does not exist {result_file}")
+
+        # get absolute path
+        result_file = result_file.absolute()
+
+        resultVars = self.sendExpression(f'readSimulationResultVars("{result_file.as_posix()}")')
         self.sendExpression("closeSimulationResultFile()")
         if varList is None:
             return resultVars
@@ -965,7 +969,7 @@ class ModelicaSystem:
         if isinstance(varList, str):
             if varList not in resultVars and varList != "time":
                 raise ModelicaSystemError(f"Requested data {repr(varList)} does not exist")
-            res = self.sendExpression(f'readSimulationResult("{resFile}", {{{varList}}})')
+            res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}", {{{varList}}})')
             npRes = np.array(res)
             self.sendExpression("closeSimulationResultFile()")
             return npRes
@@ -977,7 +981,7 @@ class ModelicaSystem:
                 if var not in resultVars:
                     raise ModelicaSystemError(f"Requested data {repr(var)} does not exist")
             variables = ",".join(varList)
-            res = self.sendExpression(f'readSimulationResult("{resFile}",{{{variables}}})')
+            res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}",{{{variables}}})')
             npRes = np.array(res)
             self.sendExpression("closeSimulationResultFile()")
             return npRes

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -961,10 +961,10 @@ class ModelicaSystem:
         # get absolute path
         result_file = result_file.absolute()
 
-        resultVars = self.sendExpression(f'readSimulationResultVars("{result_file.as_posix()}")')
+        result_vars = self.sendExpression(f'readSimulationResultVars("{result_file.as_posix()}")')
         self.sendExpression("closeSimulationResultFile()")
         if varList is None:
-            return resultVars
+            return result_vars
 
         if isinstance(varList, str):
             var_list_checked = [varList]
@@ -976,13 +976,13 @@ class ModelicaSystem:
         for var in var_list_checked:
             if var == "time":
                 continue
-            if var not in resultVars:
+            if var not in result_vars:
                 raise ModelicaSystemError(f"Requested data {repr(var)} does not exist")
         variables = ",".join(var_list_checked)
         res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}",{{{variables}}})')
-        npRes = np.array(res)
+        np_res = np.array(res)
         self.sendExpression("closeSimulationResultFile()")
-        return npRes
+        return np_res
 
     @staticmethod
     def _strip_space(name):

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -967,26 +967,22 @@ class ModelicaSystem:
             return resultVars
 
         if isinstance(varList, str):
-            if varList not in resultVars and varList != "time":
-                raise ModelicaSystemError(f"Requested data {repr(varList)} does not exist")
-            res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}", {{{varList}}})')
-            npRes = np.array(res)
-            self.sendExpression("closeSimulationResultFile()")
-            return npRes
+            var_list_checked = [varList]
+        elif isinstance(varList, list):
+            var_list_checked = varList
+        else:
+            raise ModelicaSystemError("Unhandled input for getSolutions()")
 
-        if isinstance(varList, list):
-            for var in varList:
-                if var == "time":
-                    continue
-                if var not in resultVars:
-                    raise ModelicaSystemError(f"Requested data {repr(var)} does not exist")
-            variables = ",".join(varList)
-            res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}",{{{variables}}})')
-            npRes = np.array(res)
-            self.sendExpression("closeSimulationResultFile()")
-            return npRes
-
-        raise ModelicaSystemError("Unhandled input for getSolutions()")
+        for var in var_list_checked:
+            if var == "time":
+                continue
+            if var not in resultVars:
+                raise ModelicaSystemError(f"Requested data {repr(var)} does not exist")
+        variables = ",".join(var_list_checked)
+        res = self.sendExpression(f'readSimulationResult("{result_file.as_posix()}",{{{variables}}})')
+        npRes = np.array(res)
+        self.sendExpression("closeSimulationResultFile()")
+        return npRes
 
     @staticmethod
     def _strip_space(name):


### PR DESCRIPTION
cleanup content of getSolution()

* variable names
* use pathlib.Path() if possible
* use absolute path
* simplify code if only one variable is provided (a string)