### PR TITLE
[ModelicaSystem] prepare OMCPath

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -953,14 +953,17 @@ class ModelicaSystem:
         if simargs:
             om_cmd.args_set(args=simargs)
 
-        overrideFile = self._tempdir / f"{self._model_name}_override.txt"
         if self._override_variables or self._simulate_options_override:
-            tmpdict = self._override_variables.copy()
-            tmpdict.update(self._simulate_options_override)
+            override_file = result_file.parent / f"{result_file.stem}_override.txt"
 
-            override_content = "\n".join([f"{key}={value}" for key, value in tmpdict.items()]) + "\n"
-            overrideFile.write_text(override_content)
-            om_cmd.arg_set(key="overrideFile", val=overrideFile.as_posix())
+            override_content = (
+                    "\n".join([f"{key}={value}" for key, value in self._override_variables.items()])
+                    + "\n".join([f"{key}={value}" for key, value in self._simulate_options_override.items()])
+                    + "\n"
+            )
+
+            override_file.write_text(override_content)
+            om_cmd.arg_set(key="overrideFile", val=override_file.as_posix())
 
         if self._inputs:  # if model has input quantities
             for key in self._inputs:

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -33,7 +33,6 @@ __license__ = """
 """
 
 import ast
-import csv
 from dataclasses import dataclass
 import logging
 import numbers
@@ -1421,9 +1420,10 @@ class ModelicaSystem:
         if csvfile is None:
             csvfile = self._tempdir / f'{self._model_name}.csv'
 
-        with open(file=csvfile, mode="w", encoding="utf-8", newline="") as fh:
-            writer = csv.writer(fh)
-            writer.writerows(csv_rows)
+        # basic definition of a CSV file using csv_rows as input
+        csv_content = "\n".join([",".join(map(str, row)) for row in csv_rows]) + "\n"
+
+        csvfile.write_text(csv_content)
 
         return csvfile
 

--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -957,11 +957,9 @@ class ModelicaSystem:
         if self._override_variables or self._simulate_options_override:
             tmpdict = self._override_variables.copy()
             tmpdict.update(self._simulate_options_override)
-            # write to override file
-            with open(file=overrideFile, mode="w", encoding="utf-8") as fh:
-                for key, value in tmpdict.items():
-                    fh.write(f"{key}={value}\n")
 
+            override_content = "\n".join([f"{key}={value}" for key, value in tmpdict.items()]) + "\n"
+            overrideFile.write_text(override_content)
             om_cmd.arg_set(key="overrideFile", val=overrideFile.as_posix())
 
         if self._inputs:  # if model has input quantities


### PR DESCRIPTION
needed changes to use OMCPath in ModelicaSystem

* update handling of override file
* create override file using pathlib.Path.write_text()
* do not use package csv