### PR TITLE
D004 OMSessionRunner

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -41,6 +41,10 @@ from OMPython.OMCSession import (
     OMCSessionException,
     OMCSessionLocal,
     OMCSessionPort,
+
+    OMPathRunnerBash,
+    OMPathRunnerLocal,
+
     OMCSessionWSL,
     OMCSessionZMQ,
 )
@@ -77,6 +81,10 @@ __all__ = [
     'OMCSessionException',
     'OMCSessionPort',
     'OMCSessionLocal',
+
+    'OMPathRunnerBash',
+    'OMPathRunnerLocal',
+
     'OMCSessionWSL',
     'OMCSessionZMQ',
 ]


### PR DESCRIPTION
(D004) define OMSessionRunner
    
    [(_)OMPathRunnerLocal] improve definition
    
    * fix return values
    * additional cleanups
    
    [__init__] define OMPathRunnerLocal for public interface
    
    [_OMPathRunnerBash] define class
    
    [__init__] define OMPathRunnerBash for public interface
    
    [OMSessionRunner] update code such that it can be used by OMPathRunnerLocal and OMPathRunner Bash