### PR TITLE
[backport] Do not add simulation options to overrideFile (#400) - 4.0.1

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -427,6 +427,8 @@ class ModelicaSystem:
         else:
             self._getconn = OMCSessionZMQ(omhome=omhome)
 
+        # get OpenModelica version
+        self._version = self.sendExpression("getVersion()", parsed=True)
         # set commandLineOptions using default values or the user defined list
         if commandLineOptions is None:
             # set default command line options to improve the performance of linearization and to avoid recompilation if
@@ -996,6 +998,13 @@ class ModelicaSystem:
 
         raise ModelicaSystemError("Unhandled input for getOptimizationOptions()")
 
+    def parse_om_version(self, version: str) -> tuple[int, int, int]:
+        match = re.search(r"v?(\d+)\.(\d+)\.(\d+)", version)
+        if not match:
+            raise ValueError(f"Version not found in: {version}")
+        major, minor, patch = map(int, match.groups())
+        return major, minor, patch
+
     def simulate_cmd(
             self,
             result_file: pathlib.Path,
@@ -1044,11 +1053,23 @@ class ModelicaSystem:
         if self._override_variables or self._simulate_options_override:
             override_file = result_file.parent / f"{result_file.stem}_override.txt"
 
-            override_content = (
+            # simulation options are not read from override file from version >= 1.26.0,
+            # pass them to simulation executable directly as individual arguments
+            # see https://github.com/OpenModelica/OpenModelica/pull/14813
+            major, minor, patch = self.parse_om_version(self._version)
+            if (major, minor, patch) >= (1, 26, 0):
+                for key, opt_value in self._simulate_options_override.items():
+                    om_cmd.arg_set(key=key, val=str(opt_value))
+                override_content = (
+                    "\n".join([f"{key}={value}" for key, value in self._override_variables.items()])
+                    + "\n"
+                )
+            else:
+                override_content = (
                     "\n".join([f"{key}={value}" for key, value in self._override_variables.items()])
                     + "\n".join([f"{key}={value}" for key, value in self._simulate_options_override.items()])
                     + "\n"
-            )
+                )
 
             override_file.write_text(override_content)
             om_cmd.arg_set(key="overrideFile", val=override_file.as_posix())
@@ -1642,15 +1663,26 @@ class ModelicaSystem:
             timeout=timeout,
         )
 
-        overrideLinearFile = self.getWorkDirectory() / f'{self._model_name}_override_linear.txt'
+        # See comment in simulate_cmd regarding override file and OM version
+        major, minor, patch = self.parse_om_version(self._version)
+        if (major, minor, patch) >= (1, 26, 0):
+            for key, opt_value in self._linearization_options.items():
+                om_cmd.arg_set(key=key, val=str(opt_value))
+            override_content = (
+                "\n".join([f"{key}={value}" for key, value in self._override_variables.items()])
+                + "\n"
+            )
+        else:
+            override_content = (
+                "\n".join([f"{key}={value}" for key, value in self._override_variables.items()])
+                + "\n".join([f"{key}={value}" for key, value in self._linearization_options.items()])
+                + "\n"
+            )
 
-        with open(file=overrideLinearFile, mode="w", encoding="utf-8") as fh:
-            for key1, value1 in self._override_variables.items():
-                fh.write(f"{key1}={value1}\n")
-            for key2, value2 in self._linearization_options.items():
-                fh.write(f"{key2}={value2}\n")
+        override_file = self.getWorkDirectory() / f'{self._model_name}_override_linear.txt'
+        override_file.write_text(override_content)
 
-        om_cmd.arg_set(key="overrideFile", val=overrideLinearFile.as_posix())
+        om_cmd.arg_set(key="overrideFile", val=override_file.as_posix())
 
         if self._inputs:
             for key in self._inputs:


### PR DESCRIPTION
see issue #455 - possible version 4.0.1 with just PR #400 to check for modified handling of simulation settings in OpenModelica (linter checked / no unittests etc.)