### PR TITLE
fix timeout handling

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -451,6 +451,7 @@ class ModelicaSystemABC(metaclass=abc.ABCMeta):
             cmd_local=self._session.model_execution_local,
             cmd_windows=self._session.model_execution_windows,
             cmd_prefix=self._session.model_execution_prefix(cwd=self.getWorkDirectory()),
+            timeout=self._session.set_timeout(),
             model_name=self._model_name,
         )
         # ... by running it - output help for command help
@@ -902,6 +903,7 @@ class ModelicaSystemABC(metaclass=abc.ABCMeta):
             cmd_local=self._session.model_execution_local,
             cmd_windows=self._session.model_execution_windows,
             cmd_prefix=self._session.model_execution_prefix(cwd=self.getWorkDirectory()),
+            timeout=self._session.set_timeout(),
             model_name=self._model_name,
         )
 
@@ -1394,6 +1396,7 @@ class ModelicaSystemABC(metaclass=abc.ABCMeta):
             cmd_local=self._session.model_execution_local,
             cmd_windows=self._session.model_execution_windows,
             cmd_prefix=self._session.model_execution_prefix(cwd=self.getWorkDirectory()),
+            timeout=self._session.set_timeout(),
             model_name=self._model_name,
         )
 

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -856,7 +856,7 @@ class ModelExecutionData:
 
         cmdl = self.get_cmd()
 
-        logger.debug("Run OM command %s in %s", repr(cmdl), self.cmd_path)
+        logger.debug("Run OM command %s in %s (timeout=%2fs)", repr(cmdl), self.cmd_path, self.cmd_timeout)
         try:
             cmdres = subprocess.run(
                 cmdl,
@@ -876,7 +876,8 @@ class ModelExecutionData:
             if stderr:
                 raise ModelExecutionException(f"Error running model executable {repr(cmdl)}: {stderr}")
         except subprocess.TimeoutExpired as ex:
-            raise ModelExecutionException(f"Timeout running model executable {repr(cmdl)}: {ex}") from ex
+            raise ModelExecutionException("OMPython timeout running model executable "
+                                          f"(timeout={self.cmd_timeout:.2f}s){repr(cmdl)}: {ex}") from ex
         except subprocess.CalledProcessError as ex:
             raise ModelExecutionException(f"Error running model executable {repr(cmdl)}: {ex}") from ex
 
@@ -1282,7 +1283,7 @@ class OMCSessionABC(OMSessionABC, metaclass=abc.ABCMeta):
                 log_content = 'log not available'
 
             logger.error(f"OMC did not start. Log-file says:\n{log_content}")
-            raise OMCSessionException(f"No connection with OMC (timeout={self._timeout}).")
+            raise OMCSessionException(f"No connection with OMC (timeout={self._timeout:.2f}s).")
 
         if expr == "quit()":
             self._omc_zmq.close()
@@ -1509,7 +1510,7 @@ class OMCSessionLocal(OMCSessionABC):
                 break
         else:
             logger.error(f"OMC server did not start. Log-file says:\n{self.get_log()}")
-            raise OMCSessionException(f"OMC Server did not start (timeout={self._timeout}, "
+            raise OMCSessionException(f"OMC Server did not start (timeout={self._timeout:.2f}s, "
                                       f"logfile={repr(self._omc_logfile)}).")
 
         logger.info(f"Local OMC Server is up and running at ZMQ port {port} "
@@ -1648,7 +1649,7 @@ class OMCSessionDockerABC(OMCSessionABC, metaclass=abc.ABCMeta):
                 break
         else:
             logger.error(f"Docker did not start. Log-file says:\n{self.get_log()}")
-            raise OMCSessionException(f"Docker based OMC Server did not start (timeout={self._timeout}).")
+            raise OMCSessionException(f"Docker based OMC Server did not start (timeout={self._timeout:.2f}s).")
 
         return docker_process
 
@@ -1698,7 +1699,7 @@ class OMCSessionDockerABC(OMCSessionABC, metaclass=abc.ABCMeta):
                 break
         else:
             logger.error(f"Docker did not start. Log-file says:\n{self.get_log()}")
-            raise OMCSessionException(f"Docker based OMC Server did not start (timeout={self._timeout}, "
+            raise OMCSessionException(f"Docker based OMC Server did not start (timeout={self._timeout:.2f}s, "
                                       f"logfile={repr(self._omc_logfile)}).")
 
         logger.info(f"Docker based OMC Server is up and running at port {port}")
@@ -1885,7 +1886,7 @@ class OMCSessionDocker(OMCSessionDockerABC):
             time.sleep(self._timeout / 40.0)
 
         if docker_cid is None:
-            raise OMCSessionException(f"Docker did not start (timeout={self._timeout} might be too short "
+            raise OMCSessionException(f"Docker did not start (timeout={self._timeout:.2f}s might be too short "
                                       "especially if you did not docker pull the image before this command). "
                                       f"Log-file says:\n{self.get_log()}")
 
@@ -2076,7 +2077,7 @@ class OMCSessionWSL(OMCSessionABC):
                 break
         else:
             logger.error(f"WSL based OMC server did not start. Log-file says:\n{self.get_log()}")
-            raise OMCSessionException(f"WSL based OMC Server did not start (timeout={self._timeout}, "
+            raise OMCSessionException(f"WSL based OMC Server did not start (timeout={self._timeout:2f}s, "
                                       f"logfile={repr(self._omc_logfile)}).")
 
         logger.info(f"WSL based OMC Server is up and running at ZMQ port {port} "

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -1883,7 +1883,6 @@ class OMCSessionDocker(OMCSessionDockerABC):
                 pass
             if docker_cid is not None:
                 break
-            time.sleep(self._timeout / 40.0)
 
         if docker_cid is None:
             raise OMCSessionException(f"Docker did not start (timeout={self._timeout:.2f}s might be too short "


### PR DESCRIPTION
the define timeout value (in OMCSession) is not propagated correctly to `ModelExecutionCmd()` - thus, any change does not have the desired effect

This PR additionally improves the log / error messages to also provide the value of the (OMPython) timeout.

One function (`set_timeout()`) was moved from OMCSessionABC to OMSessionABC

Reported in issue #460