### PR TITLE
fix timeout handling

### DIFF
--- a/OMPython/ModelicaSystem.py
+++ b/OMPython/ModelicaSystem.py
@@ -37,6 +37,8 @@ from OMPython.OMCSession import (
 # define logger using the current module name as ID
 logger = logging.getLogger(__name__)
 
+MODEL_EXECUTION_TIMEOUT: float = 300.0
+
 
 class ModelicaSystemError(Exception):
     """
@@ -108,7 +110,7 @@ class ModelExecutionCmd:
             cmd_prefix: list[str],
             cmd_local: bool = False,
             cmd_windows: bool = False,
-            timeout: float = 300.0,
+            timeout: Optional[float] = None,
             model_name: Optional[str] = None,
     ) -> None:
         if model_name is None:
@@ -119,7 +121,13 @@ class ModelExecutionCmd:
         self._cmd_prefix = cmd_prefix
         self._runpath = pathlib.PurePosixPath(runpath)
         self._model_name = model_name
-        self._timeout = timeout
+
+        if timeout is None:
+            # a separate timeout is defined here to allow the use of the class independent of the normal call chain via
+            # classes derived from OMSession (OMSESSION_TIMEOUT)
+            self._timeout: float = MODEL_EXECUTION_TIMEOUT
+        else:
+            self._timeout = timeout
 
         # dictionaries of command line arguments for the model executable
         self._args: dict[str, str | None] = {}
@@ -2830,14 +2838,14 @@ class ModelicaDoERunner(ModelicaDoEABC):
 
 class ModelicaSystemCmd(ModelExecutionCmd):
     """
-    Compatibility class; in the new version it is renamed as MOdelExecutionCmd.
+    Compatibility class; in the new version it is renamed as ModelExecutionCmd.
     """
 
     def __init__(
             self,
             runpath: pathlib.Path,
             modelname: str,
-            timeout: float = 300.0,
+            timeout: Optional[float] = None,
     ) -> None:
         super().__init__(
             runpath=runpath,

--- a/OMPython/OMCSession.py
+++ b/OMPython/OMCSession.py
@@ -35,6 +35,8 @@ from OMPython.OMParser import om_parser_basic
 # define logger using the current module name as ID
 logger = logging.getLogger(__name__)
 
+OMSESSION_TIMEOUT: float = 300.0
+
 
 class DockerPopen:
     """
@@ -953,7 +955,7 @@ class OMSessionABC(metaclass=OMSessionMeta):
         self.model_execution_local = False
 
         # store variables
-        self._timeout = 300.0
+        self._timeout = OMSESSION_TIMEOUT
         self.set_timeout(timeout=timeout)
         # command prefix (to be used for docker or WSL)
         self._cmd_prefix: list[str] = []
@@ -2113,7 +2115,7 @@ class OMSessionRunner(OMSessionRunnerABC):
     def __init__(
             self,
             ompath_runner: Type[OMPathRunnerABC] = OMPathRunnerLocal,
-            timeout: float = 10.0,
+            timeout: Optional[float] = None,
             version: str = "1.27.0",
             cmd_prefix: Optional[list[str]] = None,
             model_execution_local: bool = True,


### PR DESCRIPTION
1. OMSESSION_TIMEOUT - used for OMSession and derived classes
2. MODEL_EXECUTION_TIMEOUT - used for model execution

in the default code MODEL_EXECUTION_TIMEOUT = OMSESSION_TIMEOUT if ModelExecutionCmd is called internally
